### PR TITLE
Global refactoring

### DIFF
--- a/CardsNavigation.xcodeproj/project.pbxproj
+++ b/CardsNavigation.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		FA6203EC216E9D1F002EFE71 /* Timing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAB21DB214630C500AAFF48 /* Timing.swift */; };
 		FA6203ED216E9D1F002EFE71 /* SmoothInteractive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF4556216567200032C2A9 /* SmoothInteractive.swift */; };
 		FA6203EE216E9D1F002EFE71 /* LiquidTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1E8160212D3383001DA432 /* LiquidTransition.swift */; };
-		FA6203EF216E9D1F002EFE71 /* RestoreTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B5D932128BAED00B38B1C /* RestoreTransition.swift */; };
+		FA6203EF216E9D1F002EFE71 /* TransitionRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B5D932128BAED00B38B1C /* TransitionRestorer.swift */; };
 		FA6203F0216E9D1F002EFE71 /* TransitionPercentAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1E8162212D44E3001DA432 /* TransitionPercentAnimator.swift */; };
 		FA6203F2216E9DF2002EFE71 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6203F1216E9DF2002EFE71 /* Helpers.swift */; };
 		FA92B848216870750095C126 /* PhotosDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA92B847216870750095C126 /* PhotosDetailViewController.swift */; };
@@ -110,7 +110,7 @@
 		FA1E8162212D44E3001DA432 /* TransitionPercentAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionPercentAnimator.swift; sourceTree = "<group>"; };
 		FA2B5D8C2128B43C00B38B1C /* CardCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCells.swift; sourceTree = "<group>"; };
 		FA2B5D912128BAAB00B38B1C /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		FA2B5D932128BAED00B38B1C /* RestoreTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreTransition.swift; sourceTree = "<group>"; };
+		FA2B5D932128BAED00B38B1C /* TransitionRestorer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionRestorer.swift; sourceTree = "<group>"; };
 		FA2B5D952128BBCD00B38B1C /* GlobalFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalFunctions.swift; sourceTree = "<group>"; };
 		FA2B7510218AEA420065845C /* LiquidTransitionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LiquidTransitionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA2B7512218AEA420065845C /* LiquidTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidTransitionTests.swift; sourceTree = "<group>"; };
@@ -216,7 +216,7 @@
 		FA6203DE216E9CFE002EFE71 /* Liquid */ = {
 			isa = PBXGroup;
 			children = (
-				FA2B5D932128BAED00B38B1C /* RestoreTransition.swift */,
+				FA2B5D932128BAED00B38B1C /* TransitionRestorer.swift */,
 				FA6203F1216E9DF2002EFE71 /* Helpers.swift */,
 				FA1E8160212D3383001DA432 /* LiquidTransition.swift */,
 				FA94878C2135F5ED00DAE280 /* RuntimeHelper.swift */,
@@ -548,7 +548,7 @@
 				FA6203ED216E9D1F002EFE71 /* SmoothInteractive.swift in Sources */,
 				FA6203F0216E9D1F002EFE71 /* TransitionPercentAnimator.swift in Sources */,
 				FA6203E9216E9D1F002EFE71 /* RuntimeHelper.swift in Sources */,
-				FA6203EF216E9D1F002EFE71 /* RestoreTransition.swift in Sources */,
+				FA6203EF216E9D1F002EFE71 /* TransitionRestorer.swift in Sources */,
 				FA6203F2216E9DF2002EFE71 /* Helpers.swift in Sources */,
 				FA6203EE216E9D1F002EFE71 /* LiquidTransition.swift in Sources */,
 				FA6203EA216E9D1F002EFE71 /* DisplayLinkAnimator.swift in Sources */,

--- a/CardsNavigation/AppDelegate.swift
+++ b/CardsNavigation/AppDelegate.swift
@@ -14,20 +14,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func printPoints(function: CAMediaTimingFunction) {
         var cps = [Float](repeating: 0, count: 4)
         function.getControlPoint(at: 0, values: &cps[0])
         function.getControlPoint(at: 1, values: &cps[1])
         function.getControlPoint(at: 2, values: &cps[2])
         function.getControlPoint(at: 3, values: &cps[3])
-        
+
         print("p1 Point(\(cps[0]), \(cps[1]))")
         print("p2 Point(\(cps[2]), \(cps[3]))")
     }
-    
+
     func application(_ application: UIApplication,
-                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         Liquid.shared.becomeDelegate()
         Liquid.shared.addTransitions([CardTransition(),
@@ -35,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                       PhotoOpenTransition(),
                                       BrokenViewTransition(),
                                       FadeTransition()])
-        
+
         return true
     }
 
@@ -61,6 +60,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/CardsNavigation/BrokenView/TestBrokenAnimationController.swift
+++ b/CardsNavigation/BrokenView/TestBrokenAnimationController.swift
@@ -15,7 +15,7 @@ class TestBrokenAnimationController: UIViewController {
     var dismissFromPoint: CGPoint = CGPoint(x: 100, y: 100)
     var animator = BrokenViewTransition()
     @IBOutlet var smoothInteractiveSwitch: UISwitch!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -27,7 +27,6 @@ class TestBrokenAnimationController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    
 
     @IBAction func onPan(pan: UIPanGestureRecognizer) {
         if pan.state == .began {
@@ -38,10 +37,10 @@ class TestBrokenAnimationController: UIViewController {
                 // allow only swipe down dismiss
                 return
             }
-            
+
             dismissFromPoint = pan.location(in: pan.view)
             animator.percentAnimator.enableSmoothInteractive = smoothInteractiveSwitch.isOn
-            
+
             dismiss(animated: true, completion: nil)
         } else if pan.state == .changed {
             let offset = pan.translation(in: pan.view)
@@ -58,9 +57,8 @@ extension TestBrokenAnimationController: UIViewControllerTransitioningDelegate {
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return animator
     }
-    
+
     func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return self.animator.percentAnimator
     }
 }
-

--- a/CardsNavigation/BrokenView/TestBrokenAnimationController.swift
+++ b/CardsNavigation/BrokenView/TestBrokenAnimationController.swift
@@ -40,7 +40,7 @@ class TestBrokenAnimationController: UIViewController {
             }
             
             dismissFromPoint = pan.location(in: pan.view)
-            animator.interactive.enableSmoothInteractive = smoothInteractiveSwitch.isOn
+            animator.percentAnimator.enableSmoothInteractive = smoothInteractiveSwitch.isOn
             
             dismiss(animated: true, completion: nil)
         } else if pan.state == .changed {
@@ -60,7 +60,7 @@ extension TestBrokenAnimationController: UIViewControllerTransitioningDelegate {
     }
     
     func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return self.animator.interactive
+        return self.animator.percentAnimator
     }
 }
 

--- a/CardsNavigation/Cards/CardCells.swift
+++ b/CardsNavigation/Cards/CardCells.swift
@@ -11,10 +11,10 @@ import UIKit
 class CardItemCell: UICollectionViewCell {
     let cornerRadius: CGFloat = 20
     @IBOutlet var imageView: UIImageView!
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
 //        contentView.layer.cornerRadius = cornerRadius
 //        contentView.clipsToBounds = true
         imageView.layer.cornerRadius = cornerRadius

--- a/CardsNavigation/Cards/CardInfo.swift
+++ b/CardsNavigation/Cards/CardInfo.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 struct CardInfo {
     var snapshot: UIImage?
     var controller: WebViewController?

--- a/CardsNavigation/Cards/CardsNavigationController.swift
+++ b/CardsNavigation/Cards/CardsNavigationController.swift
@@ -8,8 +8,6 @@
 
 import UIKit
 
-
-
 class CardsNavigationController: UIViewController {
 
     var cards: [CardInfo] = []
@@ -18,10 +16,10 @@ class CardsNavigationController: UIViewController {
     var layout: CenteredCollectionViewFlowLayout!
     var selectedIndex = IndexPath(row: 0, section: 0)
     @IBOutlet var collection: UICollectionView!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
 //        transitioningDelegate = self
         layout = collection.collectionViewLayout as? CenteredCollectionViewFlowLayout
         layout.itemSize = CGSize(
@@ -30,28 +28,28 @@ class CardsNavigationController: UIViewController {
         )
         layout.minimumLineSpacing = 20
         layout.scrollDirection = .horizontal
-        
+
         collection.showsVerticalScrollIndicator = false
         collection.showsHorizontalScrollIndicator = false
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         if (lastOpenedCardIdx >= 0) {
             let idx = lastOpenedCardIdx
             if let img = cards[idx].controller?.getContentView().snapshotImage(scale: scaleDown) {
                 self.updateSnapshot(idx: idx, img: img)
             }
-            
+
             lastOpenedCardIdx = -1
         }
     }
-    
+
     @IBAction func closePressed() {
         dismiss(animated: true, completion: nil)
     }
-    
+
     func addNewPage() {
         let vc = WebViewController()
 //        vc.transitioningDelegate = self
@@ -60,12 +58,12 @@ class CardsNavigationController: UIViewController {
         present(vc, animated: true) {
             self.collection.insertItems(at: [IndexPath(item: self.cards.count, section: 0)])
         }
-        
+
         let newInfo = CardInfo(snapshot: nil, controller: vc)
         cards.append(newInfo)
         lastOpenedCardIdx = cards.count-1
     }
-    
+
     func openPage() {
         lastOpenedCardIdx = selectedIndex.item
         if let vc = cards[lastOpenedCardIdx].controller {
@@ -73,12 +71,12 @@ class CardsNavigationController: UIViewController {
             present(vc, animated: true, completion: nil)
         }
     }
-    
+
     func updateSnapshot(idx: Int, img: UIImage) {
         self.cards[idx].snapshot = img
         self.collection.reloadItems(at: [IndexPath(row: idx, section: 0)])
     }
-    
+
     func getTransitionCell() -> UIView {
         if let cell = collection.cellForItem(at: selectedIndex) {
             return cell.contentView
@@ -105,7 +103,7 @@ class CardsNavigationController: UIViewController {
             return tempView
         }
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 //        if let dst = segue.destination as? WebViewController {
 //            dst.transitioningDelegate = self
@@ -117,26 +115,26 @@ extension CardsNavigationController: UICollectionViewDelegateFlowLayout, UIColle
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return cards.count+1
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.row == cards.count {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "AddNew", for: indexPath)
             return cell
         }
-        
+
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Page", for: indexPath) as! CardItemCell
         cell.imageView.image = cards[indexPath.row].snapshot
         return cell
     }
-    
+
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
 //        print("Current centered index: \(String(describing: centeredCollectionViewFlowLayout.currentCenteredPage ?? nil))")
     }
-    
+
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
 //        print("Current centered index: \(String(describing: centeredCollectionViewFlowLayout.currentCenteredPage ?? nil))")
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("Selected Cell #\(indexPath.row)")
         selectedIndex = indexPath

--- a/CardsNavigation/Cards/CenteredCollectionViewFlowLayout.swift
+++ b/CardsNavigation/Cards/CenteredCollectionViewFlowLayout.swift
@@ -33,31 +33,31 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
             return itemSize.height + minimumLineSpacing
         }
     }
-    
+
     /// Calculates the current centered page.
     public var currentCenteredPage: Int? {
         guard let collectionView = collectionView else { return nil }
         let currentCenteredPoint = CGPoint(x: collectionView.contentOffset.x + collectionView.bounds.width/2, y: collectionView.contentOffset.y + collectionView.bounds.height/2)
-        
+
         return collectionView.indexPathForItem(at: currentCenteredPoint)?.row
     }
-    
+
     public override init() {
         super.init()
         scrollDirection = .horizontal
         lastScrollDirection = scrollDirection
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         scrollDirection = .horizontal
         lastScrollDirection = scrollDirection
     }
-    
+
     override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
         super.invalidateLayout(with: context)
         guard let collectionView = collectionView else { return }
-        
+
         // invalidate layout to center first and last
         let currentCollectionViewSize = collectionView.bounds.size
         if !currentCollectionViewSize.equalTo(lastCollectionViewSize) || lastScrollDirection != scrollDirection || lastItemSize != itemSize {
@@ -76,36 +76,36 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
             lastItemSize = itemSize
         }
     }
-    
+
     override open func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
         guard let collectionView = collectionView else { return proposedContentOffset }
-        
+
         let proposedRect: CGRect = determineProposedRect(collectionView: collectionView, proposedContentOffset: proposedContentOffset)
-        
+
         guard let layoutAttributes = layoutAttributesForElements(in: proposedRect),
             let candidateAttributesForRect = attributesForRect(
                 collectionView: collectionView,
                 layoutAttributes: layoutAttributes,
                 proposedContentOffset: proposedContentOffset
             ) else { return proposedContentOffset }
-        
+
         var newOffset: CGFloat
         let offset: CGFloat
         switch scrollDirection {
         case .horizontal:
             newOffset = candidateAttributesForRect.center.x - collectionView.bounds.size.width / 2
             offset = newOffset - collectionView.contentOffset.x
-            
+
             if (velocity.x < 0 && offset > 0) || (velocity.x > 0 && offset < 0) {
                 let pageWidth = itemSize.width + minimumLineSpacing
                 newOffset += velocity.x > 0 ? pageWidth : -pageWidth
             }
             return CGPoint(x: newOffset, y: proposedContentOffset.y)
-            
+
         case .vertical:
             newOffset = candidateAttributesForRect.center.y - collectionView.bounds.size.height / 2
             offset = newOffset - collectionView.contentOffset.y
-            
+
             if (velocity.y < 0 && offset > 0) || (velocity.y > 0 && offset < 0) {
                 let pageHeight = itemSize.height + minimumLineSpacing
                 newOffset += velocity.y > 0 ? pageHeight : -pageHeight
@@ -113,7 +113,7 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
             return CGPoint(x: proposedContentOffset.x, y: newOffset)
         }
     }
-    
+
     /// Programmatically scrolls to a page at a specified index.
     ///
     /// - Parameters:
@@ -121,7 +121,7 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
     ///   - animated: Whether the scroll should be performed animated.
     public func scrollToPage(index: Int, animated: Bool) {
         guard let collectionView = collectionView else { return }
-        
+
         let proposedContentOffset: CGPoint
         let shouldAnimate: Bool
         switch scrollDirection {
@@ -139,7 +139,7 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
 }
 
 private extension CenteredCollectionViewFlowLayout {
-    
+
     func determineProposedRect(collectionView: UICollectionView, proposedContentOffset: CGPoint) -> CGRect {
         let size = collectionView.bounds.size
         let origin: CGPoint
@@ -151,30 +151,30 @@ private extension CenteredCollectionViewFlowLayout {
         }
         return CGRect(origin: origin, size: size)
     }
-    
+
     func attributesForRect(
         collectionView: UICollectionView,
         layoutAttributes: [UICollectionViewLayoutAttributes],
         proposedContentOffset: CGPoint
         ) -> UICollectionViewLayoutAttributes? {
-        
+
         var candidateAttributes: UICollectionViewLayoutAttributes?
         let proposedCenterOffset: CGFloat
-        
+
         switch scrollDirection {
         case .horizontal:
             proposedCenterOffset = proposedContentOffset.x + collectionView.bounds.size.width / 2
         case .vertical:
             proposedCenterOffset = proposedContentOffset.y + collectionView.bounds.size.height / 2
         }
-        
+
         for attributes in layoutAttributes {
             guard attributes.representedElementCategory == .cell else { continue }
             guard candidateAttributes != nil else {
                 candidateAttributes = attributes
                 continue
             }
-            
+
             switch scrollDirection {
             case .horizontal where abs(attributes.center.x - proposedCenterOffset) < abs(candidateAttributes!.center.x - proposedCenterOffset):
                 candidateAttributes = attributes

--- a/CardsNavigation/Cards/GradientView.swift
+++ b/CardsNavigation/Cards/GradientView.swift
@@ -17,20 +17,20 @@ class GradientView: UIView {
     fileprivate var gradientLayer: CAGradientLayer {
         return layer as! CAGradientLayer
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
-        
+
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
     }
-    
+
     func setup() {
-        
+
         gradientLayer.locations = [0, 1]
         gradientLayer.startPoint = CGPoint(x: 0, y: 0)
         gradientLayer.endPoint = CGPoint(x: 1, y: 1)
@@ -39,7 +39,7 @@ class GradientView: UIView {
             UIColor(red: 1, green: 0.5764705882, blue: 0.462745098, alpha: 1).cgColor
         ]
     }
-    
+
     func setColors(from: UIColor, to: UIColor) {
         gradientLayer.colors = [from.cgColor, to.cgColor]
     }

--- a/CardsNavigation/Cards/web/WebViewController.swift
+++ b/CardsNavigation/Cards/web/WebViewController.swift
@@ -11,15 +11,13 @@ import WebKit
 import Liquid
 
 class WebViewController: UIViewController {
-    
+
     var web: WKWebView!
     @IBOutlet weak var statusBarView: UIView!
     @IBOutlet weak var toolbar: UIView!
-    
-    
-    
+
     var urlToLoad: URL?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -29,16 +27,16 @@ class WebViewController: UIViewController {
         web = WKWebView(frame: view.bounds.inset(top: statusBarView.frame.size.height, bottom: toolbar.bounds.height))
         web.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.addSubview(web)
-        
+
         if let url = urlToLoad {
             web.load(URLRequest(url: url))
         }
-        
+
         let pan = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(onEdgePan(pan:)))
         pan.edges = .left
         view.addGestureRecognizer(pan)
     }
-    
+
     func loadURL(url: URL) {
         if (isViewLoaded) {
             web.load(URLRequest(url: url))
@@ -50,15 +48,15 @@ class WebViewController: UIViewController {
     @IBAction func prevPagePressed() {
         web.goBack()
     }
-    
+
     @IBAction func nextPagePressed() {
         web.goForward()
     }
-    
+
     @IBAction func showCards() {
         dismiss(animated: true, completion: nil)
     }
-    
+
     @objc func onEdgePan(pan: UIScreenEdgePanGestureRecognizer) {
         switch pan.state {
         case .began:
@@ -83,11 +81,11 @@ extension WebViewController {
     func getContentView() -> UIView {
         return web
     }
-    
+
     func getToolbarView() -> UIView {
         return toolbar
     }
-    
+
     func getStatusView() -> UIView {
         return statusBarView
     }

--- a/CardsNavigation/Extensions/Extensions.swift
+++ b/CardsNavigation/Extensions/Extensions.swift
@@ -27,30 +27,30 @@ extension CGSize {
     var point: CGPoint {
         return CGPoint(x: width, y: height)
     }
-    
+
     func add(_ other: CGSize) -> CGSize {
         return CGSize(width: width + other.width, height: height + other.height)
     }
-    
+
     func substract(_ other: CGSize) -> CGSize {
         return CGSize(width: width - other.width, height: height - other.height)
     }
-    
+
     func mulitply(_ val: CGFloat) -> CGSize {
         return CGSize(width: width * val, height: height * val)
     }
-    
+
     func integral() -> CGSize {
         return CGSize(width: round(width), height: round(height))
     }
-    
+
     func aspectFit(maxSize: CGSize, maxScale: CGFloat = 0) -> CGSize {
         let scale = max(self.width / maxSize.width,
                         self.height / maxSize.height)
         if scale < maxScale { return self }
         return CGSize(width: width / scale, height: height / scale)
     }
-    
+
     func aspectFill(maxSize: CGSize, maxScale: CGFloat = 0) -> CGSize {
         let scale = min(self.width / maxSize.width,
                         self.height / maxSize.height)
@@ -70,16 +70,16 @@ extension CGRect {
         let origin = mid.substract(size.point.mulitply(0.5))
         self.init(origin: origin, size: size)
     }
-    
+
     var mid: CGPoint {
         set { origin = CGPoint(x: newValue.x - size.width / 2.0, y: newValue.y - size.height / 2.0) }
         get { return CGPoint(x: midX, y: midY) }
     }
-    
+
     func inset(top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> CGRect {
         return self.inset(by: UIEdgeInsets(top: top, left: left, bottom: bottom, right: right))
     }
-    
+
     func getAspectFit(viewSize size: CGSize) -> CGRect {
         let scale = min(self.width / size.width, self.height / size.height)
         let scaledSize = CGSize(width: scale * size.width, height: scale * size.height)
@@ -89,8 +89,6 @@ extension CGRect {
                       height: scaledSize.height)
     }
 }
-
-
 
 // MARK: - UI
 
@@ -103,32 +101,32 @@ extension UITableView {
 }
 
 extension UIDevice {
-    
+
     static let isSimulator: Bool = ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil
     static let isIPhone: Bool = UIDevice.current.userInterfaceIdiom == .phone
     static let isIPad: Bool = UIDevice.current.userInterfaceIdiom == .pad
 }
 
 extension UIImage {
-    
+
     func resizing(top: CGFloat, left: CGFloat, bott: CGFloat, right: CGFloat) -> UIImage {
         return self.resizableImage(withCapInsets: UIEdgeInsets(top: top, left: left, bottom: bott, right: right))
     }
-    
+
     func resizing(all: CGFloat) -> UIImage {
         return self.resizableImage(withCapInsets: UIEdgeInsets(top: all, left: all, bottom: all, right: all))
     }
 }
 
 extension Array where Element: Equatable {
-    
+
     // Remove first collection element that is equal to the given `object`:
     mutating func remove(object: Element) {
         if let index = index(of: object) {
             remove(at: index)
         }
     }
-    
+
     mutating func remove(objects: [Element]) {
         for obj in objects {
             remove(object: obj)
@@ -136,10 +134,9 @@ extension Array where Element: Equatable {
     }
 }
 
-
 extension Array {
-    
-    mutating func remove(filter: (Element)->(Bool)) {
+
+    mutating func remove(filter: (Element) -> (Bool)) {
         var indexes: [Int] = []
         for (idx, val) in self.enumerated() {
             if filter(val) {
@@ -156,9 +153,8 @@ extension String {
     var urlEscaped: String? {
         return addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
     }
-    
+
     func addPath(_ component: String) -> String {
         return (self as NSString).appendingPathComponent(component)
     }
 }
-

--- a/CardsNavigation/Extensions/GlobalFunctions.swift
+++ b/CardsNavigation/Extensions/GlobalFunctions.swift
@@ -12,25 +12,25 @@ extension DispatchQueue {
     static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
 }
 
-public typealias Cancelable = ()->()
+public typealias Cancelable = ()->Void
 
 func delay(_ delay: Double,
            queue: DispatchQueue = DispatchQueue.main,
-           closure:@escaping ()->()) {
+           closure:@escaping ()->Void) {
     queue.asyncAfter(deadline: .now() + delay, execute: closure)
 }
 
 func performAsyncIn(_ queue: DispatchQueue,
-                    closure: @escaping ()->()) {
+                    closure: @escaping ()->Void) {
     queue.async(execute: closure)
 }
 
 func performSyncIn(_ queue: DispatchQueue,
-                   closure: @escaping ()->()) {
+                   closure: @escaping ()->Void) {
     queue.sync(execute: closure)
 }
 
-func performInMain(closure: @escaping ()->()) {
+func performInMain(closure: @escaping ()->Void) {
     if Thread.isMainThread {
         closure()
     } else {
@@ -38,7 +38,7 @@ func performInMain(closure: @escaping ()->()) {
     }
 }
 
-func performInBackground(closure: @escaping ()->()) {
+func performInBackground(closure: @escaping ()->Void) {
     if Thread.isMainThread {
         DispatchQueue.background.async(execute: closure)
     } else {
@@ -46,19 +46,17 @@ func performInBackground(closure: @escaping ()->()) {
     }
 }
 
+private var _privateKeys = Set<String>()
 
-fileprivate var _privateKeys = Set<String>()
-
-func once(file: String = #file, line: Int = #line, col: Int = #column, _ code: ()->()) {
+func once(file: String = #file, line: Int = #line, col: Int = #column, _ code: ()->Void) {
     let key = "\(file)|\(line)|\(col)"
-    
-    objc_sync_enter(DispatchQueue.main);
+
+    objc_sync_enter(DispatchQueue.main)
     defer { objc_sync_exit(DispatchQueue.main) }
-    
+
     if _privateKeys.contains(key) {
         return
     }
     _privateKeys.insert(key)
     code()
 }
-

--- a/CardsNavigation/Extensions/UIImage+Ex.swift
+++ b/CardsNavigation/Extensions/UIImage+Ex.swift
@@ -9,17 +9,17 @@
 import UIKit
 
 extension UIImage {
-    
+
     func preloadedImage() -> UIImage {
-        
+
         guard let cgImage = cgImage else {
             return self
         }
-        
+
         // make a bitmap context of a suitable size to draw to, forcing decode
         let width = cgImage.width
         let height = cgImage.height
-        
+
         let colourSpace = CGColorSpaceCreateDeviceRGB()
         let imageContext =  CGContext(data: nil,
                                       width: width,
@@ -28,16 +28,16 @@ extension UIImage {
                                       bytesPerRow: width * 4,
                                       space: colourSpace,
                                       bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue)
-        
+
         // draw the image to the context, release it
         imageContext?.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height), byTiling: false)
-        
+
         // now get an image ref from the context
         if let outputImage = imageContext?.makeImage() {
             return UIImage(cgImage: outputImage, scale: scale, orientation: imageOrientation)
         }
-        
+
         return self
     }
-    
+
 }

--- a/CardsNavigation/Extensions/UIView+Ex.swift
+++ b/CardsNavigation/Extensions/UIView+Ex.swift
@@ -10,23 +10,23 @@ import UIKit
 
 extension UIView {
 
-    func snapshotImage(scale: CGFloat, completion: @escaping (UIImage)->(), queue: DispatchQueue? = DispatchQueue.main) {
+    func snapshotImage(scale: CGFloat, completion: @escaping (UIImage)->Void, queue: DispatchQueue? = DispatchQueue.main) {
         let selfSize = bounds.size
-        
+
         DispatchQueue.global(qos: .background).async {
-        
+
             let size = CGSize(width: floor(selfSize.width * scale),
                               height: floor(selfSize.height * scale))
             UIGraphicsBeginImageContextWithOptions(size, true, 0)
-            var img: UIImage? = nil
-            
+            var img: UIImage?
+
             if let ctx = UIGraphicsGetCurrentContext() {
                 ctx.scaleBy(x: scale, y: scale)
                 self.layer.render(in: ctx)
                 img = UIGraphicsGetImageFromCurrentImageContext()
             }
-            UIGraphicsEndImageContext();
-            
+            UIGraphicsEndImageContext()
+
             if let queue = queue {
                 queue.async { completion(img ?? UIImage()) }
             } else {
@@ -34,22 +34,22 @@ extension UIView {
             }
         }
     }
-    
+
     func snapshotImage(scale: CGFloat) -> UIImage {
         let selfSize = bounds.size
-        
+
         let size = CGSize(width: floor(selfSize.width * scale),
                           height: floor(selfSize.height * scale))
         UIGraphicsBeginImageContextWithOptions(size, true, 0)
-        var img: UIImage? = nil
-        
+        var img: UIImage?
+
         if let ctx = UIGraphicsGetCurrentContext() {
             ctx.scaleBy(x: scale, y: scale)
             self.layer.render(in: ctx)
             img = UIGraphicsGetImageFromCurrentImageContext()
         }
-        UIGraphicsEndImageContext();
-        
+        UIGraphicsEndImageContext()
+
         return img ?? UIImage()
     }
 }

--- a/CardsNavigation/Photos/PhotoCell.swift
+++ b/CardsNavigation/Photos/PhotoCell.swift
@@ -13,14 +13,14 @@ class PhotoCell: UICollectionViewCell {
     @IBOutlet var indicator: UIActivityIndicatorView!
     var cancelImageLoad: Cancelable?
     let corners: CGFloat = 5.0
-    
+
     override func prepareForReuse() {
         super.prepareForReuse()
         cancelImageLoad?()
         cancelImageLoad = nil
         imgView.image = nil
     }
-    
+
     func display(photo: PhotoInfo) {
         indicator.startAnimating()
         cancelImageLoad = ThumbCaches.shared.getImage(name: photo.assetName, size: imgView.bounds.size, corners: corners, completion: {[weak self] (img) in
@@ -28,5 +28,5 @@ class PhotoCell: UICollectionViewCell {
             self?.indicator.stopAnimating()
         })
     }
-    
+
 }

--- a/CardsNavigation/Photos/PhotoInfo.swift
+++ b/CardsNavigation/Photos/PhotoInfo.swift
@@ -8,11 +8,10 @@
 
 import UIKit
 
-
 class PhotoInfo {
     let assetName: String
     var cachedThumbImage: UIImage?
-    
+
     init(name: String) {
         assetName = name
         cachedThumbImage = nil

--- a/CardsNavigation/Photos/PhotoPreviewController.swift
+++ b/CardsNavigation/Photos/PhotoPreviewController.swift
@@ -8,24 +8,22 @@
 
 import UIKit
 
-
-
 class PhotoPreviewController: UIViewController {
 
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var indicator: UIActivityIndicatorView!
     var index: Int = 0
     var photo: PhotoInfo!
-    
+
     static func controller(photo: PhotoInfo, index: Int) -> PhotoPreviewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let controller = storyboard.instantiateViewController(withIdentifier: "PhotoPreviewController") as! PhotoPreviewController
         controller.photo = photo
         controller.index = index
-        
+
         return controller
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/CardsNavigation/Photos/PhotosDetailViewController.swift
+++ b/CardsNavigation/Photos/PhotosDetailViewController.swift
@@ -14,35 +14,35 @@ class PhotosDetailViewController: UIPageViewController {
     var photos: [PhotoInfo] = []
     var index: Int = 0
     var animTransition: PhotoCloseInteractiveTransition?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         delegate = self
         dataSource = self
-        
+
         if let vc = getViewController(forIndex: index) {
             setViewControllers([vc], direction: .forward, animated: false, completion: nil)
         }
-        
+
         let pan = UIPanGestureRecognizer(target: self, action: #selector(onPan(pan:)))
         pan.delegate = self
         view.addGestureRecognizer(pan)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         if let controllers = self.navigationController?.viewControllers,
             let prev = controllers[controllers.count-2] as? PhotosViewController {
             animTransition = Liquid.shared.transitionForDismiss(from: self, to: prev) as? PhotoCloseInteractiveTransition
             animTransition?.isEnabled = false
         }
     }
-    
+
     @objc func onPan(pan: UIPanGestureRecognizer) {
         let offset = pan.translation(in: view)
-        
+
         if pan.state == .began {
             if (offset.y < abs(offset.x)) {
                 pan.isEnabled = false
@@ -60,7 +60,7 @@ class PhotosDetailViewController: UIPageViewController {
                     self.animTransition?.isEnabled = false
                 }
             }
-            
+
         } else if pan.state == .changed {
             let progress = min(0.7, max(0, offset.y / 200.0))
             Liquid.shared.update(progress: progress)
@@ -69,7 +69,7 @@ class PhotosDetailViewController: UIPageViewController {
             Liquid.shared.complete()
         }
     }
-    
+
 }
 
 extension PhotosDetailViewController: UIGestureRecognizerDelegate {
@@ -99,21 +99,21 @@ extension PhotosDetailViewController: UIPageViewControllerDelegate, UIPageViewCo
 //        }
         return PhotoPreviewController.controller(photo: photos[index], index: index)
     }
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let vc = viewController as? PhotoPreviewController else {
             return nil
         }
         return getViewController(forIndex: vc.index - 1)
     }
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let vc = viewController as? PhotoPreviewController else {
             return nil
         }
         return getViewController(forIndex: vc.index + 1)
     }
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if completed {
             if let newIndex = (viewControllers?.first as? PhotoPreviewController)?.index {

--- a/CardsNavigation/Photos/PhotosViewController.swift
+++ b/CardsNavigation/Photos/PhotosViewController.swift
@@ -20,20 +20,19 @@ class PhotosViewController: UICollectionViewController {
                                PhotoInfo(name: "img5"),
                                PhotoInfo(name: "img6"),
                                PhotoInfo(name: "img7")]
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let prefferedCellSize = floor((UIScreen.main.bounds.width - 10 * 4) / 3.0)
         let flowLayout = collectionView?.collectionViewLayout as? UICollectionViewFlowLayout
         flowLayout?.itemSize = CGSize(width: prefferedCellSize, height: prefferedCellSize)
-        
-        
+
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         navigationController?.delegate = Liquid.shared
     }
 
@@ -44,13 +43,12 @@ class PhotosViewController: UICollectionViewController {
             detailVC.index = idx
         }
     }
-    
+
     // MARK: UICollectionViewDataSource
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
-
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return photos.count
@@ -60,10 +58,10 @@ class PhotosViewController: UICollectionViewController {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? PhotoCell else {
             return UICollectionViewCell()
         }
-    
+
         cell.display(photo: photos[indexPath.row])
         // Configure the cell
-    
+
         return cell
     }
 

--- a/CardsNavigation/Photos/ThumbCaches.swift
+++ b/CardsNavigation/Photos/ThumbCaches.swift
@@ -11,18 +11,18 @@ import UIKit
 class ThumbCaches: NSObject {
 
     static let shared = ThumbCaches()
-    
+
     fileprivate var cache: NSCache<NSString, UIImage>!
     fileprivate var queue: DispatchQueue!
-    
+
     override init() {
         cache = NSCache<NSString, UIImage>()
         cache.countLimit = 20
         queue = DispatchQueue(label: "Draw Images BG", qos: DispatchQoS.background)
         super.init()
     }
-    
-    func getImage(name: String, size: CGSize, corners: CGFloat, completion: @escaping (UIImage)->()) -> Cancelable {
+
+    func getImage(name: String, size: CGSize, corners: CGFloat, completion: @escaping (UIImage)->Void) -> Cancelable {
         let key = name + "| \(size.width)x\(size.height) \(corners)"
         if let img = cache.object(forKey: key as NSString) {
             completion(img)
@@ -40,16 +40,16 @@ class ThumbCaches: NSObject {
         }
         return { isCanceled = true }
     }
-    
+
     fileprivate func prepareImage(name: String, size: CGSize, corners: CGFloat) -> UIImage {
         guard let img = UIImage(named: name) else {
             return UIImage()
         }
-        
+
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
-        
+
         UIBezierPath(roundedRect: CGRect(origin: CGPoint.zero, size: size), cornerRadius: corners).addClip()
-        
+
         let scale = max(size.width / img.size.width, size.height / img.size.height)
         let offset = CGPoint(x: (size.width - img.size.width * scale) / 2.0,
                              y: (size.height - img.size.height * scale) / 2.0)
@@ -59,7 +59,7 @@ class ThumbCaches: NSObject {
                             height: img.size.height * scale))
         let result = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         return result ?? UIImage()
     }
 }

--- a/CardsNavigation/Transitions/BrokenViewTransition.swift
+++ b/CardsNavigation/Transitions/BrokenViewTransition.swift
@@ -102,7 +102,7 @@ class BrokenViewTransition: TransitionAnimator<TestBrokenAnimationController, UI
     }
     
     
-    override func animation(vc1: TestBrokenAnimationController, vc2: UIViewController, container: UIView, duration: Double) {
+    override func animateTransition(from vc1: TestBrokenAnimationController, to vc2: UIViewController, container: UIView, duration: Double) {
         let point = vc1.dismissFromPoint
         let brokenPieces = broke(view: vc1.view, fromPoint: point)
         for view in brokenPieces {

--- a/CardsNavigation/Transitions/CardTransition.swift
+++ b/CardsNavigation/Transitions/CardTransition.swift
@@ -26,15 +26,14 @@ struct AnimationHelper {
 class CardTransition: TransitionAnimator<CardsNavigationController, WebViewController> {
     var clipContainer: UIView!
     var scaleFactor: CGFloat = 1.0
-    
+
     init() {
         super.init(from: CardsNavigationController.self, to: WebViewController.self, direction: .both)
-        
+
         duration = 0.7
         addCustomAnimation(animateCornerRadius)
     }
-    
-    
+
     override func animateTransition(from vc1: CardsNavigationController,
                             to vc2: WebViewController,
                             container: UIView,
@@ -43,17 +42,16 @@ class CardTransition: TransitionAnimator<CardsNavigationController, WebViewContr
         let content = vc2.getContentView()
         let startContentFrame = content.frame
         let card = vc1.getTransitionCell()
-        
+
         restore.addRestoreViews(content)
         let cardFrame = card.convert(card.bounds, to: container)
-        
+
         let scale = max(cardFrame.width / content.bounds.width,
                         cardFrame.height / content.bounds.height)
         scaleFactor = scale
         content.transform = CGAffineTransform(scaleX: scale, y: scale)
         content.center = CGPoint(x: cardFrame.midX, y: cardFrame.midY)
-        
-        
+
         clipContainer = UIView(frame: CGRect(x: 0,
                                              y: 0,
                                              width: cardFrame.width / scale,
@@ -62,28 +60,28 @@ class CardTransition: TransitionAnimator<CardsNavigationController, WebViewContr
         clipContainer.clipsToBounds = true
         clipContainer.backgroundColor = UIColor.white
         content.mask = clipContainer
-        
+
         let toolbar = vc2.toolbar!
         restore.addRestoreViews(toolbar)
         let toolbarFrame = toolbar.frame
         toolbar.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
         toolbar.frame = toolbarFrame
         toolbar.layer.transform = AnimationHelper.xRotation(.pi * 0.6)
-        
+
         let status = vc2.statusBarView!
         restore.addRestoreViews(status)
         let statusFrame = status.frame
         status.layer.anchorPoint = CGPoint(x: 0.5, y: 0)
         status.frame = statusFrame
         status.layer.transform = AnimationHelper.xRotation(-.pi * 0.6)
-        
+
         UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: {
             content.transform = .identity
             self.clipContainer.frame = content.bounds
             content.frame = startContentFrame
             toolbar.layer.transform = CATransform3DIdentity
             status.layer.transform = CATransform3DIdentity
-        }) { (finished) in
+        }) { (_) in
             content.mask = nil
             toolbar.layer.transform = CATransform3DIdentity
             status.layer.transform = CATransform3DIdentity
@@ -91,7 +89,7 @@ class CardTransition: TransitionAnimator<CardsNavigationController, WebViewContr
             restore.restore()
         }
     }
-    
+
     func animateCornerRadius(_ percent: CGFloat) {
         if let clip = clipContainer {
             clip.layer.cornerRadius = 20 / scaleFactor * (1-percent)

--- a/CardsNavigation/Transitions/CardTransition.swift
+++ b/CardsNavigation/Transitions/CardTransition.swift
@@ -35,16 +35,16 @@ class CardTransition: TransitionAnimator<CardsNavigationController, WebViewContr
     }
     
     
-    override func animation(vc1: CardsNavigationController,
-                            vc2: WebViewController,
+    override func animateTransition(from vc1: CardsNavigationController,
+                            to vc2: WebViewController,
                             container: UIView,
                             duration: Double) {
-        let restore = RestoreTransition()
+        let restore = TransitionRestorer()
         let content = vc2.getContentView()
         let startContentFrame = content.frame
         let card = vc1.getTransitionCell()
         
-        restore.addRestore(content)
+        restore.addRestoreViews(content)
         let cardFrame = card.convert(card.bounds, to: container)
         
         let scale = max(cardFrame.width / content.bounds.width,
@@ -64,14 +64,14 @@ class CardTransition: TransitionAnimator<CardsNavigationController, WebViewContr
         content.mask = clipContainer
         
         let toolbar = vc2.toolbar!
-        restore.addRestore(toolbar)
+        restore.addRestoreViews(toolbar)
         let toolbarFrame = toolbar.frame
         toolbar.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
         toolbar.frame = toolbarFrame
         toolbar.layer.transform = AnimationHelper.xRotation(.pi * 0.6)
         
         let status = vc2.statusBarView!
-        restore.addRestore(status)
+        restore.addRestoreViews(status)
         let statusFrame = status.frame
         status.layer.anchorPoint = CGPoint(x: 0.5, y: 0)
         status.frame = statusFrame

--- a/CardsNavigation/Transitions/FadeTransition.swift
+++ b/CardsNavigation/Transitions/FadeTransition.swift
@@ -17,7 +17,7 @@ class FadeTransition: TransitionAnimator<UIViewController, CardsNavigationContro
         duration = 0.3
     }
     
-    override func animation(vc1: UIViewController, vc2: CardsNavigationController, container: UIView, duration: Double) {
+    override func animateTransition(from vc1: UIViewController, to vc2: CardsNavigationController, container: UIView, duration: Double) {
         vc2.view.alpha = 0
         UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: {
             vc2.view.alpha = 1

--- a/CardsNavigation/Transitions/FadeTransition.swift
+++ b/CardsNavigation/Transitions/FadeTransition.swift
@@ -13,10 +13,10 @@ class FadeTransition: TransitionAnimator<UIViewController, CardsNavigationContro
 
     init() {
         super.init(from: UIViewController.self, to: CardsNavigationController.self, direction: .both)
-        
+
         duration = 0.3
     }
-    
+
     override func animateTransition(from vc1: UIViewController, to vc2: CardsNavigationController, container: UIView, duration: Double) {
         vc2.view.alpha = 0
         UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: {

--- a/CardsNavigation/Transitions/PhotoCloseInteractiveTransition.swift
+++ b/CardsNavigation/Transitions/PhotoCloseInteractiveTransition.swift
@@ -28,7 +28,7 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
         }
     }
     
-    override func animation(vc1: PhotosDetailViewController, vc2: PhotosViewController, container: UIView, duration: Double) {
+    override func animateTransition(from vc1: PhotosDetailViewController, to vc2: PhotosViewController, container: UIView, duration: Double) {
         guard let cell = vc2.collectionView?.cellForItem(at: IndexPath(item: vc1.index, section: 0)) as? PhotoCell else {
             print("Something went wrong")
             return
@@ -42,7 +42,7 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
         fromFrame = vc2.view.bounds.getAspectFit(viewSize: imgView.image!.size)
         corners = cell.corners
         
-        let restore = RestoreTransition(keyPaths: SaveViewState(path: \.contentMode))
+        let restore = TransitionRestorer(keyPaths: SaveViewState(path: \.contentMode))
         restore.moveView(imgView, to: container)
         
         animImageView = imgView
@@ -51,8 +51,8 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
         animImageView.layer.masksToBounds = true
         animImageView.layer.cornerRadius = cell.corners
         
-        restore.addRestore(cell.imgView)
-        restore.addRestore(vc1.view, ignoreFields: [.superview])
+        restore.addRestoreViews(cell.imgView)
+        restore.addRestoreView(vc1.view, ignoreFields: [.superview])
         
         cell.imgView.isHidden = true
         
@@ -64,7 +64,7 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
         }
     }
     
-    override func completeInteractiveTransition(vc1: PhotosDetailViewController, vc2: PhotosViewController, isPresenting: Bool, finish: Bool, animationDuration: Double) {
+    override func completeInteractiveTransition(from: PhotosDetailViewController, to: PhotosViewController, isPresenting: Bool, finish: Bool, animationDuration: Double) {
         UIView.animate(withDuration: animationDuration, delay: 0, options: [.curveLinear], animations: {
             self.animImageView.frame = finish ? self.toFrame : self.fromFrame
         }, completion: nil)

--- a/CardsNavigation/Transitions/PhotoCloseInteractiveTransition.swift
+++ b/CardsNavigation/Transitions/PhotoCloseInteractiveTransition.swift
@@ -15,10 +15,10 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
     fileprivate var corners: CGFloat = 0
     fileprivate var toFrame: CGRect = .zero
     fileprivate var fromFrame: CGRect = .zero
-    
+
     init() {
         super.init(from: PhotosDetailViewController.self, to: PhotosViewController.self, direction: .dismiss)
-        
+
         duration = 0.4
         timing = Timing.easeOutExpo
         addCustomAnimation { [weak self] (progress) in
@@ -27,7 +27,7 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
             print("progress", progress)
         }
     }
-    
+
     override func animateTransition(from vc1: PhotosDetailViewController, to vc2: PhotosViewController, container: UIView, duration: Double) {
         guard let cell = vc2.collectionView?.cellForItem(at: IndexPath(item: vc1.index, section: 0)) as? PhotoCell else {
             print("Something went wrong")
@@ -41,21 +41,21 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
         toFrame = cell.imgView.convert(cell.imgView.bounds, to: container)
         fromFrame = vc2.view.bounds.getAspectFit(viewSize: imgView.image!.size)
         corners = cell.corners
-        
+
         let restore = TransitionRestorer(keyPaths: SaveViewState(path: \.contentMode))
         restore.moveView(imgView, to: container)
-        
+
         animImageView = imgView
         animImageView.frame = fromFrame
         animImageView.contentMode = .scaleAspectFill
         animImageView.layer.masksToBounds = true
         animImageView.layer.cornerRadius = cell.corners
-        
+
         restore.addRestoreViews(cell.imgView)
         restore.addRestoreView(vc1.view, ignoreFields: [.superview])
-        
+
         cell.imgView.isHidden = true
-        
+
         print("Custom duration", TimeInterval(duration))
         UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: {
             vc1.view.alpha = 0
@@ -63,13 +63,13 @@ class PhotoCloseInteractiveTransition: TransitionAnimator<PhotosDetailViewContro
             restore.restore()
         }
     }
-    
+
     override func completeInteractiveTransition(from: PhotosDetailViewController, to: PhotosViewController, isPresenting: Bool, finish: Bool, animationDuration: Double) {
         UIView.animate(withDuration: animationDuration, delay: 0, options: [.curveLinear], animations: {
             self.animImageView.frame = finish ? self.toFrame : self.fromFrame
         }, completion: nil)
     }
-    
+
     func updateInteractive(offset: CGPoint, progress: CGFloat) {
         let mid = fromFrame.mid.add(offset)
         let size = fromFrame.size.interpolation(to: toFrame.size, progress: progress)

--- a/CardsNavigation/Transitions/PhotoOpenTransition.swift
+++ b/CardsNavigation/Transitions/PhotoOpenTransition.swift
@@ -25,7 +25,7 @@ class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetail
         }
     }
     
-    override func animation(vc1: PhotosViewController, vc2: PhotosDetailViewController, container: UIView, duration: Double) {
+    override func animateTransition(from vc1: PhotosViewController, to vc2: PhotosDetailViewController, container: UIView, duration: Double) {
         guard let cell = vc1.collectionView?.cellForItem(at: IndexPath(item: vc2.index, section: 0)) as? PhotoCell else {
             print("Something went wrong")
             return
@@ -40,13 +40,13 @@ class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetail
         animImageView.layer.masksToBounds = true
         animImageView.layer.cornerRadius = cell.corners
         
-        let restore = RestoreTransition()
+        let restore = TransitionRestorer()
         let contentVC = vc2.viewControllers?.first as? PhotoPreviewController
         let detailContentView = contentVC?.imageView
-        restore.addRestore(animImageView, cell.imgView)
-        restore.addRestore(vc2.view, ignoreFields: [.superview])
+        restore.addRestoreViews(animImageView, cell.imgView)
+        restore.addRestoreView(vc2.view, ignoreFields: [.superview])
         if let content = detailContentView {
-            restore.addRestore(content)
+            restore.addRestoreViews(content)
         }
         
         vc2.view.alpha = 0

--- a/CardsNavigation/Transitions/PhotoOpenTransition.swift
+++ b/CardsNavigation/Transitions/PhotoOpenTransition.swift
@@ -10,13 +10,13 @@ import UIKit
 import Liquid
 
 class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetailViewController> {
-    
+
     fileprivate var animImageView: UIImageView!
     fileprivate var corners: CGFloat = 0
-    
+
     init() {
         super.init(from: PhotosViewController.self, to: PhotosDetailViewController.self, direction: .both)
-        
+
         duration = 0.35
         timing = Timing.easeOutSine
         addCustomAnimation { [weak self] (progress) in
@@ -24,7 +24,7 @@ class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetail
             self.animImageView?.layer.cornerRadius = self.corners * 2.0 * max(0, 0.5 - progress)
         }
     }
-    
+
     override func animateTransition(from vc1: PhotosViewController, to vc2: PhotosDetailViewController, container: UIView, duration: Double) {
         guard let cell = vc1.collectionView?.cellForItem(at: IndexPath(item: vc2.index, section: 0)) as? PhotoCell else {
             print("Something went wrong")
@@ -33,13 +33,13 @@ class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetail
         let photo = vc1.photos[vc2.index]
         let frame = cell.imgView.convert(cell.imgView.bounds, to: container)
         corners = cell.corners
-        
+
         animImageView = UIImageView(frame: frame)
         animImageView.contentMode = .scaleAspectFill
         animImageView.image = UIImage(named: photo.assetName)
         animImageView.layer.masksToBounds = true
         animImageView.layer.cornerRadius = cell.corners
-        
+
         let restore = TransitionRestorer()
         let contentVC = vc2.viewControllers?.first as? PhotoPreviewController
         let detailContentView = contentVC?.imageView
@@ -48,11 +48,11 @@ class PhotoOpenTransition: TransitionAnimator<PhotosViewController, PhotosDetail
         if let content = detailContentView {
             restore.addRestoreViews(content)
         }
-        
+
         vc2.view.alpha = 0
         detailContentView?.isHidden = true
         cell.imgView.isHidden = true
-        
+
         container.addSubview(animImageView)
         UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: {
             self.animImageView.frame = vc2.view.bounds.getAspectFit(viewSize: self.animImageView.image!.size)

--- a/CardsNavigation/ViewController.swift
+++ b/CardsNavigation/ViewController.swift
@@ -20,6 +20,4 @@ class ViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
 
-
 }
-

--- a/Liquid/DisplayLinkAnimator.swift
+++ b/Liquid/DisplayLinkAnimator.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Timer on **DisplayLink**
-public class DisplayLinkAnimator: NSObject {
+public final class DisplayLinkAnimator: NSObject {
     public static func animate(duration: Double, closure: @escaping (CGFloat)->()) -> Cancelable {
         let anim = DisplayLinkAnimator(duration: duration, closure: closure)
         anim.retainSelf = anim
@@ -17,7 +17,7 @@ public class DisplayLinkAnimator: NSObject {
     }
     
     // MARK: - private
-    fileprivate init(duration: Double, closure: @escaping (CGFloat)->()) {
+    private init(duration: Double, closure: @escaping (CGFloat)->()) {
         self.duration = duration
         self.closure = closure
         super.init()
@@ -26,17 +26,17 @@ public class DisplayLinkAnimator: NSObject {
         link.add(to: .current, forMode: .default)
     }
     
-    fileprivate func cancel() {
+    private func cancel() {
         link.invalidate()
     }
     
-    fileprivate var closure: (CGFloat)->()
-    fileprivate var link: CADisplayLink!
-    fileprivate var duration: Double
-    fileprivate var retainSelf: Any?
-    fileprivate var startTimeStamp: CFTimeInterval = 0
+    private var closure: (CGFloat)->()
+    private var link: CADisplayLink!
+    private var duration: Double
+    private var retainSelf: Any?
+    private var startTimeStamp: CFTimeInterval = 0
     
-    @objc fileprivate func step(link: CADisplayLink) {
+    @objc private func step(link: CADisplayLink) {
         if startTimeStamp == 0 {
             startTimeStamp = link.timestamp - link.duration
         }

--- a/Liquid/DisplayLinkAnimator.swift
+++ b/Liquid/DisplayLinkAnimator.swift
@@ -10,38 +10,38 @@ import UIKit
 
 /// Timer on **DisplayLink**
 public final class DisplayLinkAnimator: NSObject {
-    public static func animate(duration: Double, closure: @escaping (CGFloat)->()) -> Cancelable {
+    public static func animate(duration: Double, closure: @escaping (CGFloat)->Void) -> Cancelable {
         let anim = DisplayLinkAnimator(duration: duration, closure: closure)
         anim.retainSelf = anim
         return anim.cancel
     }
-    
+
     // MARK: - private
-    private init(duration: Double, closure: @escaping (CGFloat)->()) {
+    private init(duration: Double, closure: @escaping (CGFloat)->Void) {
         self.duration = duration
         self.closure = closure
         super.init()
-        
+
         link = CADisplayLink.init(target: self, selector: #selector(step(link:)))
         link.add(to: .current, forMode: .default)
     }
-    
+
     private func cancel() {
         link.invalidate()
     }
-    
-    private var closure: (CGFloat)->()
+
+    private var closure: (CGFloat)->Void
     private var link: CADisplayLink!
     private var duration: Double
     private var retainSelf: Any?
     private var startTimeStamp: CFTimeInterval = 0
-    
+
     @objc private func step(link: CADisplayLink) {
         if startTimeStamp == 0 {
             startTimeStamp = link.timestamp - link.duration
         }
         var progress = (link.timestamp - startTimeStamp) / duration
-        
+
         if progress >= 1 {
             link.invalidate()
             progress = 1
@@ -49,7 +49,7 @@ public final class DisplayLinkAnimator: NSObject {
                 retainSelf = nil
             }
         }
-        
+
         closure(CGFloat(progress))
     }
 }

--- a/Liquid/Helpers.swift
+++ b/Liquid/Helpers.swift
@@ -12,25 +12,25 @@ extension DispatchQueue {
     static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
 }
 
-public typealias Cancelable = ()->()
+public typealias Cancelable = ()->Void
 
 func delay(_ delay: Double,
            queue: DispatchQueue = DispatchQueue.main,
-           closure:@escaping ()->()) {
+           closure:@escaping ()->Void) {
     queue.asyncAfter(deadline: .now() + delay, execute: closure)
 }
 
 func performAsyncIn(_ queue: DispatchQueue,
-                    closure: @escaping ()->()) {
+                    closure: @escaping ()->Void) {
     queue.async(execute: closure)
 }
 
 func performSyncIn(_ queue: DispatchQueue,
-                   closure: @escaping ()->()) {
+                   closure: @escaping ()->Void) {
     queue.sync(execute: closure)
 }
 
-func performInMain(closure: @escaping ()->()) {
+func performInMain(closure: @escaping ()->Void) {
     if Thread.isMainThread {
         closure()
     } else {
@@ -38,7 +38,7 @@ func performInMain(closure: @escaping ()->()) {
     }
 }
 
-func performInBackground(closure: @escaping ()->()) {
+func performInBackground(closure: @escaping ()->Void) {
     if Thread.isMainThread {
         DispatchQueue.background.async(execute: closure)
     } else {
@@ -46,15 +46,14 @@ func performInBackground(closure: @escaping ()->()) {
     }
 }
 
+private var _privateKeys = Set<String>()
 
-fileprivate var _privateKeys = Set<String>()
-
-func once(file: String = #file, line: Int = #line, col: Int = #column, _ code: ()->()) {
+func once(file: String = #file, line: Int = #line, col: Int = #column, _ code: ()->Void) {
     let key = "\(file)|\(line)|\(col)"
-    
-    objc_sync_enter(DispatchQueue.main);
+
+    objc_sync_enter(DispatchQueue.main)
     defer { objc_sync_exit(DispatchQueue.main) }
-    
+
     if _privateKeys.contains(key) {
         return
     }

--- a/Liquid/LiquidTransition.swift
+++ b/Liquid/LiquidTransition.swift
@@ -8,10 +8,11 @@
 
 import UIKit
 
-
-public class Liquid: NSObject {
+public final class Liquid: NSObject {
 
     public static var shared = Liquid()
+
+    public internal(set) var currentTransition: LiquidTransitionProtocol?
     
     public struct Direction: OptionSet {
         public let rawValue: UInt
@@ -81,7 +82,6 @@ public class Liquid: NSObject {
         transition.completeInteractive(complete: finish, animated: animated)
     }
     
-    
     public func transitionForPresent(from: UIViewController, to: UIViewController) -> LiquidTransitionProtocol? {
         let transition = transitions.first(where: {$0.canAnimate(from: from, to: to, direction: .present)})
         return transition
@@ -109,9 +109,8 @@ public class Liquid: NSObject {
         return transition
     }
     
-    public internal(set) var currentTransition: LiquidTransitionProtocol?
-    fileprivate var transitions: [LiquidTransitionProtocolInternal] = []
-    fileprivate var isSwizzled: Bool = false
+    private var transitions: [LiquidTransitionProtocolInternal] = []
+    private var isSwizzled: Bool = false
 }
 
 extension UIViewController {
@@ -136,17 +135,16 @@ extension Liquid: UIViewControllerTransitioningDelegate, UINavigationControllerD
     }
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return (animator as? LiquidTransitionProtocol)?.interactive
+        return (animator as? LiquidTransitionProtocol)?.percentAnimator
     }
 
     public func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return (animator as? LiquidTransitionProtocol)?.interactive
+        return (animator as? LiquidTransitionProtocol)?.percentAnimator
     }
     
     public func navigationController(_ navigationController: UINavigationController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return (animationController as? LiquidTransitionProtocol)?.interactive
+        return (animationController as? LiquidTransitionProtocol)?.percentAnimator
     }
-    
     
     public func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         if operation == .push {

--- a/Liquid/RuntimeHelper.swift
+++ b/Liquid/RuntimeHelper.swift
@@ -9,18 +9,18 @@
 import UIKit
 
 class LiquidRuntimeHelper {
-    
+
     private init() {
     }
-    
+
     static func addOrReplaceMethod(class tClass: AnyClass, original: Selector, swizzled: Selector) {
         guard let swizzledMethod = class_getInstanceMethod(tClass, swizzled) else { return }
-        
+
         let isMethodExists: Bool = !class_addMethod(tClass, original, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-        
+
         if isMethodExists {
             if let originalMethod = class_getInstanceMethod(tClass, original) {
-                method_exchangeImplementations(originalMethod, swizzledMethod);
+                method_exchangeImplementations(originalMethod, swizzledMethod)
             }
         }
     }

--- a/Liquid/SmoothInteractive.swift
+++ b/Liquid/SmoothInteractive.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-class SmoothInteractive: NSObject {
+final class SmoothInteractive: NSObject {
     var isRunning: Bool { return self.cancelable != nil }
-    fileprivate var cancelable: Cancelable?
-    fileprivate var lastValue: CGFloat = 0
-    fileprivate var lastProgress: CGFloat = 0
+    private var cancelable: Cancelable?
+    private var lastValue: CGFloat = 0
+    private var lastProgress: CGFloat = 0
     
     func run(duration: TimeInterval, update: @escaping (CGFloat)->()) {
         cancelable = DisplayLinkAnimator.animate(duration: duration) {[weak self] (progress) in

--- a/Liquid/SmoothInteractive.swift
+++ b/Liquid/SmoothInteractive.swift
@@ -13,8 +13,8 @@ final class SmoothInteractive: NSObject {
     private var cancelable: Cancelable?
     private var lastValue: CGFloat = 0
     private var lastProgress: CGFloat = 0
-    
-    func run(duration: TimeInterval, update: @escaping (CGFloat)->()) {
+
+    func run(duration: TimeInterval, update: @escaping (CGFloat)->Void) {
         cancelable = DisplayLinkAnimator.animate(duration: duration) {[weak self] (progress) in
             guard let `self` = self else { return }
             if progress == 1.0 { self.cancelable = nil }
@@ -22,16 +22,16 @@ final class SmoothInteractive: NSObject {
             update(self.getValue())
         }
     }
-    
+
     func cancel() {
         cancelable?()
         cancelable = nil
     }
-    
+
     func update(val: CGFloat) {
         self.lastValue = val
     }
-    
+
     func getValue() -> CGFloat {
         return lastValue * lastProgress
     }

--- a/Liquid/Timing.swift
+++ b/Liquid/Timing.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class Timing {
+public final class Timing {
     
     public static let `default`: Timing = Timing(functionName: .default)
     public static let linear: Timing = Timing(closure: {$0})
@@ -53,17 +53,17 @@ public class Timing {
     
     // MARK: - Private
     
-    fileprivate var p1: CGPoint = .zero
-    fileprivate var p2: CGPoint = CGPoint(x: 1, y: 1)
-    fileprivate var cx: CGFloat = 0
-    fileprivate var bx: CGFloat = 0
-    fileprivate var ax: CGFloat = 0
-    fileprivate var cy: CGFloat = 0
-    fileprivate var by: CGFloat = 0
-    fileprivate var ay: CGFloat = 0
-    fileprivate var customClosure: ((CGFloat)->(CGFloat))? = nil
+    private var p1: CGPoint = .zero
+    private var p2: CGPoint = CGPoint(x: 1, y: 1)
+    private var cx: CGFloat = 0
+    private var bx: CGFloat = 0
+    private var ax: CGFloat = 0
+    private var cy: CGFloat = 0
+    private var by: CGFloat = 0
+    private var ay: CGFloat = 0
+    private var customClosure: ((CGFloat)->(CGFloat))? = nil
     
-    fileprivate func updateCoefficients() {
+    private func updateCoefficients() {
         cx = 3.0 * p1.x
         bx = 3.0 * (p2.x - p1.x) - cx
         ax = 1.0 - cx - bx
@@ -73,20 +73,20 @@ public class Timing {
         ay = 1.0 - cy - by
     }
     
-    fileprivate func getSampleCurveX(t: CGFloat) -> CGFloat {
+    private func getSampleCurveX(t: CGFloat) -> CGFloat {
         return ((ax * t + bx) * t + cx) * t
     }
     
-    fileprivate func getSampleCurveY(t: CGFloat) -> CGFloat {
+    private func getSampleCurveY(t: CGFloat) -> CGFloat {
         return ((ay * t + by) * t + cy) * t
     }
     
-    fileprivate func getSampleCurveDerivativeX(t: CGFloat) -> CGFloat {
+    private func getSampleCurveDerivativeX(t: CGFloat) -> CGFloat {
         return (3.0 * ax * t + 2.0 * bx) * t + cx
     }
     
     
-    fileprivate func solve(x: CGFloat, epsilon: CGFloat) -> CGFloat {
+    private func solve(x: CGFloat, epsilon: CGFloat) -> CGFloat {
         var t0: CGFloat = 0
         var t1: CGFloat = 0
         var t2: CGFloat = x
@@ -182,7 +182,7 @@ extension Timing {
     }
     
     
-    fileprivate static func easeOutBounceFunc(t: CGFloat) -> CGFloat {
+    private static func easeOutBounceFunc(t: CGFloat) -> CGFloat {
         if (t < 4.0 / 11.0) {
             return pow(11.0 / 4.0, 2) * pow(t, 2)
         }

--- a/Liquid/Timing.swift
+++ b/Liquid/Timing.swift
@@ -9,50 +9,50 @@
 import UIKit
 
 public final class Timing {
-    
+
     public static let `default`: Timing = Timing(functionName: .default)
     public static let linear: Timing = Timing(closure: {$0})
     public static let easeIn: Timing = Timing(functionName: .easeIn)
     public static let easeOut: Timing = Timing(functionName: .easeOut)
     public static let easeInOut: Timing = Timing(functionName: .easeInEaseOut)
-    
+
     public convenience init(functionName: CAMediaTimingFunctionName) {
         self.init(function: CAMediaTimingFunction(name: functionName))
     }
-    
+
     public convenience init(function: CAMediaTimingFunction) {
-        var p1: [Float] = [0.0,0.0]
-        var p2: [Float] = [0.0,0.0]
-        
+        var p1: [Float] = [0.0, 0.0]
+        var p2: [Float] = [0.0, 0.0]
+
         function.getControlPoint(at: 1, values: &p1)
         function.getControlPoint(at: 2, values: &p2)
-        
+
         self.init(cp1: CGPoint(x: CGFloat(p1[0]), y: CGFloat(p1[1])),
                   cp2: CGPoint(x: CGFloat(p2[0]), y: CGFloat(p2[1])))
     }
-    
+
     public init(cp1: CGPoint, cp2: CGPoint) {
         p1 = cp1
         p2 = cp2
         updateCoefficients()
     }
-    
-    public init(closure: @escaping (CGFloat)->(CGFloat)) {
+
+    public init(closure: @escaping (CGFloat) -> (CGFloat)) {
         customClosure = closure
     }
-    
+
     public func getValue(x: CGFloat, duration: CGFloat = 1.0) -> CGFloat {
         if let closure = customClosure {
             return closure(x)
         }
-        
+
         let eps = 1.0 / (200.0 * duration)
         let t = solve(x: x, epsilon: eps)
         return getSampleCurveY(t: t)
     }
-    
+
     // MARK: - Private
-    
+
     private var p1: CGPoint = .zero
     private var p2: CGPoint = CGPoint(x: 1, y: 1)
     private var cx: CGFloat = 0
@@ -61,64 +61,63 @@ public final class Timing {
     private var cy: CGFloat = 0
     private var by: CGFloat = 0
     private var ay: CGFloat = 0
-    private var customClosure: ((CGFloat)->(CGFloat))? = nil
-    
+    private var customClosure: ((CGFloat) -> (CGFloat))?
+
     private func updateCoefficients() {
         cx = 3.0 * p1.x
         bx = 3.0 * (p2.x - p1.x) - cx
         ax = 1.0 - cx - bx
-        
+
         cy = 3.0 * p1.y
         by = 3.0 * (p2.y - p1.y) - cy
         ay = 1.0 - cy - by
     }
-    
+
     private func getSampleCurveX(t: CGFloat) -> CGFloat {
         return ((ax * t + bx) * t + cx) * t
     }
-    
+
     private func getSampleCurveY(t: CGFloat) -> CGFloat {
         return ((ay * t + by) * t + cy) * t
     }
-    
+
     private func getSampleCurveDerivativeX(t: CGFloat) -> CGFloat {
         return (3.0 * ax * t + 2.0 * bx) * t + cx
     }
-    
-    
+
     private func solve(x: CGFloat, epsilon: CGFloat) -> CGFloat {
         var t0: CGFloat = 0
         var t1: CGFloat = 0
         var t2: CGFloat = x
         var x2: CGFloat = 0
         var d2: CGFloat = 0
-        
+
         // First try a few iterations of Newton's method -- normally very fast.
         for _ in 0..<8 {
             x2 = getSampleCurveX(t: t2) - x
             if (abs(x2) < epsilon) {
                 return t2
             }
-            
+
             d2 = getSampleCurveDerivativeX(t: t2)
             if (abs(d2) < 1e-6) {
                 break
             }
             t2 = t2 - x2 / d2
         }
-        
+
         // Fall back to the bisection method for reliability.
         t0 = 0.0
         t1 = 1.0
         t2 = x
-        
+
         if (t2 < t0) {
             return t0
         }
         if (t2 > t1) {
             return t1
         }
-        
+
         while (t0 < t1) {
             x2 = getSampleCurveX(t: t2)
             if (abs(x2 - x) < epsilon) {
@@ -131,7 +130,7 @@ public final class Timing {
             }
             t2 = (t1 + t0) * 0.5
         }
-        
+
         // Failure.
         return t2
     }
@@ -143,31 +142,31 @@ extension Timing {
     public static let easeInSine = Timing(cp1: CGPoint(x: 0.47, y: 0), cp2: CGPoint(x: 0.745, y: 0.715))
     public static let easeOutSine = Timing(cp1: CGPoint(x: 0.39, y: 0.575), cp2: CGPoint(x: 0.565, y: 1))
     public static let easeInOutSine = Timing(cp1: CGPoint(x: 0.445, y: 0.05), cp2: CGPoint(x: 0.55, y: 0.95))
-    
+
     public static let easeInQuad = Timing(cp1: CGPoint(x: 0.55, y: 0.085), cp2: CGPoint(x: 0.68, y: 0.53))
     public static let easeOutQuad = Timing(cp1: CGPoint(x: 0.25, y: 0.46), cp2: CGPoint(x: 0.45, y: 0.94))
     public static let easeInOutQuad = Timing(cp1: CGPoint(x: 0.455, y: 0.03), cp2: CGPoint(x: 0.515, y: 0.955))
-    
+
     public static let easeInCubic = Timing(cp1: CGPoint(x: 0.55, y: 0.055), cp2: CGPoint(x: 0.675, y: 0.19))
     public static let easeOutCubic = Timing(cp1: CGPoint(x: 0.215, y: 0.61), cp2: CGPoint(x: 0.355, y: 1))
     public static let easeInOutCubic = Timing(cp1: CGPoint(x: 0.645, y: 0.045), cp2: CGPoint(x: 0.355, y: 1))
-    
+
     public static let easeInQuart = Timing(cp1: CGPoint(x: 0.895, y: 0.03), cp2: CGPoint(x: 0.685, y: 0.22))
     public static let easeOutQuart = Timing(cp1: CGPoint(x: 0.165, y: 0.84), cp2: CGPoint(x: 0.44, y: 1))
     public static let easeInOutQuart = Timing(cp1: CGPoint(x: 0.77, y: 0), cp2: CGPoint(x: 0.175, y: 1))
-    
+
     public static let easeInQuint = Timing(cp1: CGPoint(x: 0.755, y: 0.05), cp2: CGPoint(x: 0.855, y: 0.06))
     public static let easeOutQuint = Timing(cp1: CGPoint(x: 0.23, y: 1), cp2: CGPoint(x: 0.32, y: 1))
     public static let easeInOutQuint = Timing(cp1: CGPoint(x: 0.86, y: 0), cp2: CGPoint(x: 0.07, y: 1))
-    
+
     public static let easeInExpo = Timing(cp1: CGPoint(x: 0.95, y: 0.05), cp2: CGPoint(x: 0.795, y: 0.035))
     public static let easeOutExpo = Timing(cp1: CGPoint(x: 0.19, y: 1), cp2: CGPoint(x: 0.22, y: 1))
-    public static let easeInOutExpo = Timing(cp1: CGPoint(x: 1, y:0), cp2: CGPoint(x: 0, y: 1))
-    
+    public static let easeInOutExpo = Timing(cp1: CGPoint(x: 1, y: 0), cp2: CGPoint(x: 0, y: 1))
+
     public static let easeInCirc = Timing(cp1: CGPoint(x: 0.6, y: 0.04), cp2: CGPoint(x: 0.98, y: 0.335))
     public static let easeOutCirc = Timing(cp1: CGPoint(x: 0.075, y: 0.82), cp2: CGPoint(x: 0.165, y: 1))
     public static let easeInOutCirc = Timing(cp1: CGPoint(x: 0.785, y: 0.135), cp2: CGPoint(x: 0.15, y: 0.86))
-    
+
     public static let easeInBack = Timing(cp1: CGPoint(x: 0.6, y: -0.28), cp2: CGPoint(x: 0.735, y: 0.045))
     public static let easeOutBack = Timing(cp1: CGPoint(x: 0.175, y: 0.885), cp2: CGPoint(x: 0.32, y: 1.275))
     public static let easeInOutBack = Timing(cp1: CGPoint(x: 0.68, y: -0.55), cp2: CGPoint(x: 0.265, y: 1.55))
@@ -175,26 +174,25 @@ extension Timing {
 
 // additional closure curves
 extension Timing {
-    
+
     public static let easeOutBounce = Timing(closure: easeOutBounceFunc)
     public static let easeInBounce = Timing { (t) -> (CGFloat) in
         return  1.0 - easeOutBounceFunc(t: 1.0 - t)
     }
-    
-    
+
     private static func easeOutBounceFunc(t: CGFloat) -> CGFloat {
         if (t < 4.0 / 11.0) {
             return pow(11.0 / 4.0, 2) * pow(t, 2)
         }
-        
+
         if (t < 8.0 / 11.0) {
-            return 3.0 / 4.0 + pow(11.0 / 4.0, 2) * pow(t - 6.0 / 11.0, 2);
+            return 3.0 / 4.0 + pow(11.0 / 4.0, 2) * pow(t - 6.0 / 11.0, 2)
         }
-        
+
         if (t < 10.0 / 11.0) {
-            return 15.0 / 16.0 + pow(11.0 / 4.0, 2) * pow(t - 9.0 / 11.0, 2);
+            return 15.0 / 16.0 + pow(11.0 / 4.0, 2) * pow(t - 9.0 / 11.0, 2)
         }
-        
-        return 63.0 / 64.0 + pow(11.0 / 4.0, 2) * pow(t - 21.0 / 22.0, 2);
+
+        return 63.0 / 64.0 + pow(11.0 / 4.0, 2) * pow(t - 21.0 / 22.0, 2)
     }
 }

--- a/Liquid/TransitionAnimator.swift
+++ b/Liquid/TransitionAnimator.swift
@@ -11,7 +11,7 @@ import UIKit
 public protocol LiquidTransitionProtocol: UIViewControllerAnimatedTransitioning {
     var progress: CGFloat { get set }
     var duration: CGFloat { get set }
-    var interactive: TransitionPercentAnimator { get }
+    var percentAnimator: TransitionPercentAnimator { get }
     var isPresenting: Bool { get }
     var isEnabled: Bool { get }
     
@@ -23,54 +23,98 @@ internal protocol LiquidTransitionProtocolInternal: LiquidTransitionProtocol {
     var isPresenting: Bool { get set }
 }
 
-open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInternal  {
+open class TransitionAnimator<Source: UIViewController, Destination: UIViewController>: MutipleTransitionAnimator {
+
+    public init(from: Source.Type, to: Destination.Type, direction: Direction) {
+        super.init(from: [from], to: [to], direction: direction)
+    }
+
+    open override func animateTransition(from vc1: UIViewController,
+                                         to vc2: UIViewController,
+                                         container: UIView,
+                                         duration: TimeInterval) {
+        guard let vc1 = vc1 as? Source, let vc2 = vc2 as? Destination else {
+            assertionFailure("Inconsitent state of the transition animator")
+            return
+        }
+        self.animateTransition(from: vc1, to: vc2, container: container, duration: duration)
+    }
+
+    open func animateTransition(from vc1: Source,
+                                to vc2: Destination,
+                                container: UIView,
+                                duration: TimeInterval) {
+        super.animateTransition(from: vc1, to: vc2, container: container, duration: duration)
+    }
+
+    open override func prepareAnimation(vc1: UIViewController, vc2: UIViewController, isPresenting: Bool) {
+        super.prepareAnimation(vc1: vc1, vc2: vc2, isPresenting: isPresenting)
+        guard let vc1 = vc1 as? Source, let vc2 = vc2 as? Destination else {
+            assertionFailure("Inconsitent state of the transition animator")
+            return
+        }
+        self.prepareAnimation(vc1: vc1, vc2: vc2, isPresenting: isPresenting)
+    }
+
+    open func prepareAnimation(vc1: Source, vc2: Destination, isPresenting: Bool) {
+        
+    }
+
+    open override func completeInteractiveTransition(from vc1: UIViewController,
+                                            to vc2: UIViewController,
+                                            isPresenting: Bool,
+                                            finish: Bool,
+                                            animationDuration: Double) {
+        guard let vc1 = vc1 as? Source, let vc2 = vc2 as? Destination else {
+            assertionFailure("Inconsitent state of the transition animator")
+            return
+        }
+        self.completeInteractiveTransition(from: vc1, to: vc2, isPresenting: isPresenting, finish: finish, animationDuration: animationDuration)
+    }
+
+    open func completeInteractiveTransition(from vc1: Source,
+                                                     to vc2: Destination,
+                                                     isPresenting: Bool,
+                                                     finish: Bool,
+                                                     animationDuration: Double) {
+
+    }
+}
+
+open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal {
     
-    public typealias CustomAnimation = (_ progress: CGFloat)->()
-    public typealias ControllerCheckClosure = (_ vc1: UIViewController, _ vc2: UIViewController, _ dir: Direction) -> Bool
     public typealias Direction = Liquid.Direction
-    
+    public typealias CustomAnimation = (_ progress: CGFloat) -> Void
+    private typealias ControllerCheckClosure = (_ vc1: UIViewController, _ vc2: UIViewController, _ direction: Direction) -> Bool
     
     public var progress: CGFloat {
-        get { return interactive.percentComplete }
-        set { interactive.update(newValue) }
+        get { return percentAnimator.percentComplete }
+        set { percentAnimator.update(newValue) }
     }
     
     public var isEnabled: Bool = true
     public var duration: CGFloat = 1.0
-    public let direction: Direction
     public var timing: Timing {
-        get { return interactive.timing }
-        set { interactive.timing = newValue }
+        get { return percentAnimator.timing }
+        set { percentAnimator.timing = newValue }
     }
-    public let interactive = TransitionPercentAnimator()
+    public let percentAnimator = TransitionPercentAnimator()
     public internal(set) var isPresenting: Bool = true
+
+    fileprivate let direction: Direction
+    fileprivate var customAnimations: [CustomAnimation] = []
+    private var controllerCheck: ControllerCheckClosure!
+    private let fromTypes: [AnyClass]
+    private let toTypes: [AnyClass]
     
-    
-    public init(from: VC1.Type, to: VC2.Type, direction: Direction) {
-        self.direction = direction
-        fromTypes = [from as! AnyClass]
-        toTypes = [to as! AnyClass]
-        super.init()
-        interactive.delegate = self
-    }
     
     public init(from: [AnyClass], to: [AnyClass], direction: Direction) {
         self.direction = direction
         fromTypes = from
         toTypes = to
         super.init()
-        interactive.delegate = self
+        percentAnimator.delegate = self
     }
-    
-    public init(direction: Direction) {
-        self.direction = direction
-        fromTypes = []
-        toTypes = []
-        super.init()
-        controllerCheck = { (_, _, _) -> Bool in false }
-        interactive.delegate = self
-    }
-    
     /// You can animate non animatable properties
     public func addCustomAnimation(_ closure: @escaping CustomAnimation) {
         customAnimations.append(closure)
@@ -80,15 +124,17 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
     //       MARK: - Overrides
     // -------------------------------
     /// Override to move information between controllers
-    open func prepareAnimation(vc1: VC1, vc2: VC2, isPresenting: Bool) {
+    open func prepareAnimation(vc1: UIViewController, vc2: UIViewController, isPresenting: Bool) {
     }
     
     /// Perform here you animation
-    open func animation(vc1: VC1, vc2: VC2, container: UIView, duration: Double) {
-        let className = String(describing: self)
-        print("LiquidTransition warning: override \(className).animation(vc1: VC1, vc2: VC2, container: UIView, duration: Double) method")
+    open func animateTransition(from vc1: UIViewController,
+                                to vc2: UIViewController,
+                                container: UIView,
+                                duration: TimeInterval) {
+        print("LiquidTransition warning: override \(String(describing: self)).\(#function)")
         
-        guard let toView = (vc2 as? UIViewController)?.view else { return }
+        guard let toView = vc2.view else { return }
         
         toView.alpha = 0
         UIView.animate(withDuration: Double(duration), animations: {
@@ -98,26 +144,29 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
         }
     }
     
-    open func completeInteractiveTransition(vc1: VC1, vc2: VC2, isPresenting: Bool, finish: Bool, animationDuration: Double) {
+    open func completeInteractiveTransition(from vc1: UIViewController,
+                                            to vc2: UIViewController,
+                                            isPresenting: Bool,
+                                            finish: Bool,
+                                            animationDuration: Double) {
         // override to animate interactive view to destanation location
     }
     
     /// You can override to perform more complex logic
     open func canAnimate(from: UIViewController, to: UIViewController, direction animDirection: Direction) -> Bool {
-        if !direction.contains(animDirection) { return false }
-        if fromTypes.count == 0 || toTypes.count == 0 {
+        if fromTypes.isEmpty || toTypes.isEmpty {
             let className = String(describing: self)
-            print("LiquidTransition warning: override \(className).canAnimate(from: UIViewController, to: UIViewController, direction: Direction) -> Bool method")
+            print("LiquidTransition warning: override \(className).\(#function)")
             return false
         }
-        
+
         var from = from
         var to = to
         // check is backward
         if direction.contains(.both) && animDirection.contains(.dismiss) {
             swap(&from, &to)
         }
-        
+
         if fromTypes.contains(where: {from.isKind(of: $0)}) &&
             toTypes.contains(where: {to.isKind(of: $0)}) {
             return true
@@ -135,8 +184,8 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
     }
 
     public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        interactive.context = transitionContext
-        interactive.totalDuration = transitionDuration(using: transitionContext)
+        percentAnimator.context = transitionContext
+        percentAnimator.totalDuration = transitionDuration(using: transitionContext)
         if let (vc1, vc2, _) = getControllers(context: transitionContext) {
             prepareAnimation(vc1: vc1, vc2: vc2, isPresenting: isPresenting)
         }
@@ -150,11 +199,10 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
             }
         }
         
-        
         if let (vc1, vc2, backward) = getControllers(context: transitionContext) {
             Liquid.shared.currentTransition = self
-            interactive.reset()
-            interactive.backward = backward
+            percentAnimator.reset()
+            percentAnimator.backward = backward
             
             if backward {
                 // fix wrong first frame
@@ -167,16 +215,16 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
                 }
             }
             
-            animation(vc1: vc1, vc2: vc2, container: transitionContext.containerView, duration: Double(duration))
-            interactive.update(0)
-            interactive.animate(finish: true, speed: 1)
+            animateTransition(from: vc1, to: vc2, container: transitionContext.containerView, duration: TimeInterval(duration))
+            percentAnimator.update(0)
+            percentAnimator.animate(finish: true, speed: 1)
         }
     }
     
     
     func callPrepareInteractive(finish: Bool, animDuration: Double) {
-        if let (vc1, vc2, _) = getControllers(context: interactive.context) {
-            completeInteractiveTransition(vc1: vc1, vc2: vc2, isPresenting: isPresenting, finish: finish, animationDuration: animDuration)
+        if let (vc1, vc2, _) = getControllers(context: percentAnimator.context) {
+            completeInteractiveTransition(from: vc1, to: vc2, isPresenting: isPresenting, finish: finish, animationDuration: animDuration)
         }
     }
     
@@ -186,41 +234,36 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
             var speed: CGFloat = 0
             if let complete = complete {
                 finish = complete
-                if finish == interactive.needFinish() {
-                    speed = abs(interactive.lastSpeed)
+                if finish == percentAnimator.needFinish() {
+                    speed = abs(percentAnimator.lastSpeed)
                 }
             } else {
-                finish = interactive.needFinish()
-                speed = abs(interactive.lastSpeed)
+                finish = percentAnimator.needFinish()
+                speed = abs(percentAnimator.lastSpeed)
             }
-            let animDuration = Double(interactive.getDurationToState(finish: finish, speed: speed))
+            let animDuration = Double(percentAnimator.getDurationToState(finish: finish, speed: speed))
             callPrepareInteractive(finish: finish, animDuration: animDuration)
-            interactive.animate(finish: finish, speed: speed)
+            percentAnimator.animate(finish: finish, speed: speed)
         } else {
-            let finish = complete ?? interactive.needFinish()
+            let finish = complete ?? percentAnimator.needFinish()
             progress = finish ? 1 : 0
-            interactive.backward = false
+            percentAnimator.backward = false
             if finish {
-                interactive.update(1)
+                percentAnimator.update(1)
                 callPrepareInteractive(finish: finish, animDuration: 0)
-                interactive.finish()
+                percentAnimator.finish()
             } else {
-                interactive.update(0)
+                percentAnimator.update(0)
                 callPrepareInteractive(finish: finish, animDuration: 0)
-                interactive.cancel()
+                percentAnimator.cancel()
             }
         }
     }
     
     
-    // MARK: - Fileprivate
+    // MARK: - Private
     
-    fileprivate var customAnimations: [CustomAnimation] = []
-    fileprivate var controllerCheck: ControllerCheckClosure!
-    fileprivate let fromTypes: [AnyClass]
-    fileprivate let toTypes: [AnyClass]
-    
-    fileprivate func runDefaultAnimation(context: UIViewControllerContextTransitioning) {
+    private func runDefaultAnimation(context: UIViewControllerContextTransitioning) {
         guard let toView = context.view(forKey: .to),
             let fromView = context.view(forKey: .from) else {
             context.completeTransition(true)
@@ -244,23 +287,20 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
         }
     }
     
-    fileprivate func getControllers(context: UIViewControllerContextTransitioning?) -> (vc1: VC1, vc2: VC2, backward: Bool)? {
+    private func getControllers(context: UIViewControllerContextTransitioning?) -> (vc1: UIViewController, vc2: UIViewController, backward: Bool)? {
         let to = context?.viewController(forKey: .to)
         let from = context?.viewController(forKey: .from)
-        
-        if let vc1 = to as? VC1, let vc2 = from as? VC2,
-           !isPresenting && direction == .both
-        {
+
+        if let vc1 = to, let vc2 = from, !isPresenting && direction == .both {
             return (vc1, vc2, true)
-        } else if let vc1 = from as? VC1, let vc2 = to as? VC2
-        {
+        } else if let vc1 = from, let vc2 = to {
             return (vc1, vc2, false)
         }
-        
+
         return nil
     }
     
-    fileprivate func makeNonVisibleChanges(view: UIView) {
+    private func makeNonVisibleChanges(view: UIView) {
         // change background color a little
         let color = view.backgroundColor ?? UIColor.clear
         var white: CGFloat = 0
@@ -277,8 +317,8 @@ open class TransitionAnimator<VC1, VC2>: NSObject, LiquidTransitionProtocolInter
 }
 
 
-extension TransitionAnimator: TransitionPercentAnimatorDelegate {
-    internal func transitionPercentChanged(_ percent: CGFloat) {
+extension MutipleTransitionAnimator: TransitionPercentAnimatorDelegate {
+    func transitionPercentChanged(_ percent: CGFloat) {
         let isBackwardAnimation = !isPresenting && direction == .both
         let animPercent = isBackwardAnimation ? 1-percent : percent
         for closure in customAnimations {

--- a/Liquid/TransitionAnimator.swift
+++ b/Liquid/TransitionAnimator.swift
@@ -14,7 +14,7 @@ public protocol LiquidTransitionProtocol: UIViewControllerAnimatedTransitioning 
     var percentAnimator: TransitionPercentAnimator { get }
     var isPresenting: Bool { get }
     var isEnabled: Bool { get }
-    
+
     func completeInteractive(complete: Bool?, animated: Bool)
     func canAnimate(from: UIViewController, to: UIViewController, direction: Liquid.Direction) -> Bool
 }
@@ -57,7 +57,7 @@ open class TransitionAnimator<Source: UIViewController, Destination: UIViewContr
     }
 
     open func prepareAnimation(vc1: Source, vc2: Destination, isPresenting: Bool) {
-        
+
     }
 
     open override func completeInteractiveTransition(from vc1: UIViewController,
@@ -82,16 +82,16 @@ open class TransitionAnimator<Source: UIViewController, Destination: UIViewContr
 }
 
 open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal {
-    
+
     public typealias Direction = Liquid.Direction
     public typealias CustomAnimation = (_ progress: CGFloat) -> Void
     private typealias ControllerCheckClosure = (_ vc1: UIViewController, _ vc2: UIViewController, _ direction: Direction) -> Bool
-    
+
     public var progress: CGFloat {
         get { return percentAnimator.percentComplete }
         set { percentAnimator.update(newValue) }
     }
-    
+
     public var isEnabled: Bool = true
     public var duration: CGFloat = 1.0
     public var timing: Timing {
@@ -106,8 +106,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
     private var controllerCheck: ControllerCheckClosure!
     private let fromTypes: [AnyClass]
     private let toTypes: [AnyClass]
-    
-    
+
     public init(from: [AnyClass], to: [AnyClass], direction: Direction) {
         self.direction = direction
         fromTypes = from
@@ -119,23 +118,23 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
     public func addCustomAnimation(_ closure: @escaping CustomAnimation) {
         customAnimations.append(closure)
     }
-    
+
     // -------------------------------
-    //       MARK: - Overrides
+    // MARK: - Overrides
     // -------------------------------
     /// Override to move information between controllers
     open func prepareAnimation(vc1: UIViewController, vc2: UIViewController, isPresenting: Bool) {
     }
-    
+
     /// Perform here you animation
     open func animateTransition(from vc1: UIViewController,
                                 to vc2: UIViewController,
                                 container: UIView,
                                 duration: TimeInterval) {
         print("LiquidTransition warning: override \(String(describing: self)).\(#function)")
-        
+
         guard let toView = vc2.view else { return }
-        
+
         toView.alpha = 0
         UIView.animate(withDuration: Double(duration), animations: {
             toView.alpha = 1
@@ -143,7 +142,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
             toView.alpha = 0
         }
     }
-    
+
     open func completeInteractiveTransition(from vc1: UIViewController,
                                             to vc2: UIViewController,
                                             isPresenting: Bool,
@@ -151,7 +150,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
                                             animationDuration: Double) {
         // override to animate interactive view to destanation location
     }
-    
+
     /// You can override to perform more complex logic
     open func canAnimate(from: UIViewController, to: UIViewController, direction animDirection: Direction) -> Bool {
         if fromTypes.isEmpty || toTypes.isEmpty {
@@ -173,12 +172,11 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
         }
         return false
     }
-    
-    
+
     // -------------------------------
-    //    MARK: - Internal methods
+    // MARK: - Internal methods
     // -------------------------------
-    
+
     public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return TimeInterval(duration)
     }
@@ -189,7 +187,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
         if let (vc1, vc2, _) = getControllers(context: transitionContext) {
             prepareAnimation(vc1: vc1, vc2: vc2, isPresenting: isPresenting)
         }
-        
+
         if let toView = transitionContext.view(forKey: .to) {
             toView.transform = .identity
             toView.frame = transitionContext.containerView.bounds
@@ -198,12 +196,12 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
                 transitionContext.containerView.sendSubviewToBack(toView)
             }
         }
-        
+
         if let (vc1, vc2, backward) = getControllers(context: transitionContext) {
             Liquid.shared.currentTransition = self
             percentAnimator.reset()
             percentAnimator.backward = backward
-            
+
             if backward {
                 // fix wrong first frame
                 // image flick between end backward animation and it's start
@@ -214,20 +212,19 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
                     }
                 }
             }
-            
+
             animateTransition(from: vc1, to: vc2, container: transitionContext.containerView, duration: TimeInterval(duration))
             percentAnimator.update(0)
             percentAnimator.animate(finish: true, speed: 1)
         }
     }
-    
-    
+
     func callPrepareInteractive(finish: Bool, animDuration: Double) {
         if let (vc1, vc2, _) = getControllers(context: percentAnimator.context) {
             completeInteractiveTransition(from: vc1, to: vc2, isPresenting: isPresenting, finish: finish, animationDuration: animDuration)
         }
     }
-    
+
     public func completeInteractive(complete: Bool?, animated: Bool) {
         if (animated) {
             var finish = true
@@ -259,17 +256,16 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
             }
         }
     }
-    
-    
+
     // MARK: - Private
-    
+
     private func runDefaultAnimation(context: UIViewControllerContextTransitioning) {
         guard let toView = context.view(forKey: .to),
             let fromView = context.view(forKey: .from) else {
             context.completeTransition(true)
             return
         }
-        
+
         context.containerView.addSubview(toView)
         toView.frame = context.containerView.bounds
         toView.alpha = 0
@@ -278,7 +274,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
         }) { (_) in
             toView.alpha = 1
             fromView.removeFromSuperview()
-            
+
             if context.transitionWasCancelled {
                 context.cancelInteractiveTransition()
             } else {
@@ -286,7 +282,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
             }
         }
     }
-    
+
     private func getControllers(context: UIViewControllerContextTransitioning?) -> (vc1: UIViewController, vc2: UIViewController, backward: Bool)? {
         let to = context?.viewController(forKey: .to)
         let from = context?.viewController(forKey: .from)
@@ -299,7 +295,7 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
 
         return nil
     }
-    
+
     private func makeNonVisibleChanges(view: UIView) {
         // change background color a little
         let color = view.backgroundColor ?? UIColor.clear
@@ -311,11 +307,10 @@ open class MutipleTransitionAnimator: NSObject, LiquidTransitionProtocolInternal
         } else {
             white += 0.001
         }
-        
+
         view.backgroundColor = UIColor.init(white: white, alpha: alpha)
     }
 }
-
 
 extension MutipleTransitionAnimator: TransitionPercentAnimatorDelegate {
     func transitionPercentChanged(_ percent: CGFloat) {
@@ -325,7 +320,7 @@ extension MutipleTransitionAnimator: TransitionPercentAnimatorDelegate {
             closure(animPercent)
         }
     }
-    
+
     func transitionCompleted(context: UIViewControllerContextTransitioning) {
         if context.transitionWasCancelled {
             context.view(forKey: .to)?.removeFromSuperview()

--- a/Liquid/TransitionPercentAnimator.swift
+++ b/Liquid/TransitionPercentAnimator.swift
@@ -28,11 +28,11 @@ public class InvertableInteractiveTransition: UIPercentDrivenInteractiveTransiti
     }
 }
 
-public class TransitionPercentAnimator: InvertableInteractiveTransition {
+public final class TransitionPercentAnimator: InvertableInteractiveTransition {
     
-    fileprivate var cancelAnimation: Cancelable?
-    fileprivate(set) var lastSpeed: CGFloat = 0
-    fileprivate(set) var lastUpdateTime: TimeInterval = 0
+    private var cancelAnimation: Cancelable?
+    private(set) var lastSpeed: CGFloat = 0
+    private(set) var lastUpdateTime: TimeInterval = 0
     weak var context: UIViewControllerContextTransitioning?
     var totalDuration: Double = 0
     public var maxDurationFactor: Double = 2.0
@@ -40,7 +40,7 @@ public class TransitionPercentAnimator: InvertableInteractiveTransition {
     var isCanceled: Bool = false
     
     public var enableSmoothInteractive: Bool = false
-    fileprivate lazy var smoothInteractive = SmoothInteractive()
+    private lazy var smoothInteractive = SmoothInteractive()
     
     /// Max completion speed after interactive transition calls complete
     public var maxCompleteionSpeed: CGFloat = 1.0
@@ -124,16 +124,21 @@ public class TransitionPercentAnimator: InvertableInteractiveTransition {
         }
     }
     
+    func reset() {
+        lastSpeed = 0
+        lastUpdateTime = 0
+        backward = false
+    }
     
     // MARK: - private
     
-    fileprivate func internalUpdate(_ percentComplete: CGFloat) {
+    private func internalUpdate(_ percentComplete: CGFloat) {
         updateSpeedWith(percentComplete: percentComplete)
         super.update(percentComplete)
         delegate?.transitionPercentChanged(percent)
     }
     
-    fileprivate func performSmoothInteractive(percent percentComplete: CGFloat, canInitalize: Bool) -> Bool {
+    private func performSmoothInteractive(percent percentComplete: CGFloat, canInitalize: Bool) -> Bool {
         if !enableSmoothInteractive { return false }
         
         if canInitalize && percentComplete > 0.05 {
@@ -150,7 +155,7 @@ public class TransitionPercentAnimator: InvertableInteractiveTransition {
         return false
     }
     
-    fileprivate func updateSpeedWith(percentComplete: CGFloat) {
+    private func updateSpeedWith(percentComplete: CGFloat) {
         let currTime = CACurrentMediaTime()
         if (percentComplete - self.percentComplete) == 0 {
             return // nothing to update
@@ -171,11 +176,5 @@ public class TransitionPercentAnimator: InvertableInteractiveTransition {
             lastSpeed = minCompleteionSpeed * (lastSpeed > 0 ? 1 : -1)
         }
         lastUpdateTime = currTime
-    }
-    
-    internal func reset() {
-        lastSpeed = 0
-        lastUpdateTime = 0
-        backward = false
     }
 }

--- a/LiquidTransitionTests/LiquidTransitionTests.swift
+++ b/LiquidTransitionTests/LiquidTransitionTests.swift
@@ -24,18 +24,18 @@ class LiquidTransitionTests: XCTestCase {
     var toVC: TVC2!
     var transition: Transition!
     var window: UIWindow!
-    
+
     override func setUp() {
         transition = Transition()
         Liquid.shared.addTransition(transition)
         fromVC = TVC1()
         toVC = TVC2()
-        
+
         // init window for test is animation is really works
         window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         window.rootViewController = fromVC
         window.makeKeyAndVisible()
-        
+
         fromVC.loadView()
     }
 
@@ -45,14 +45,14 @@ class LiquidTransitionTests: XCTestCase {
     }
 
     func testBackwardAnimation() {
-        
+
         let callExpectation = expectation(description: "Presented")
         let operationExpectation = expectation(description: "Dismissed")
-        
+
         let testDuration: CGFloat = 0.2
         transition.duration = testDuration
         var appear = true
-        var prevVal: CGFloat? = nil
+        var prevVal: CGFloat?
         transition.addCustomAnimation { (val) in
             if prevVal == nil {
                 prevVal = val
@@ -62,20 +62,20 @@ class LiquidTransitionTests: XCTestCase {
             } else {
                 XCTAssert(prevVal! >= val)
             }
-            
+
             prevVal = val
         }
-        
+
         fromVC.present(toVC, animated: true, completion: {
             appear = false
             prevVal = nil
             callExpectation.fulfill()
-            
+
             self.toVC.dismiss(animated: true, completion: {
                 operationExpectation.fulfill()
             })
         })
-        
+
         waitForExpectations(timeout: 0.6) { (error) in
             print(error?.localizedDescription)
         }

--- a/Voronoi/Edge.swift
+++ b/Voronoi/Edge.swift
@@ -7,38 +7,36 @@
 //
 
 import Foundation
-public class Edge{
+public class Edge {
     ///pointer to start point
-    public var start:Point
+    public var start: Point
     ///pointer to Voronoi place on the left side of edge
-    let left:Point
+    let left: Point
     ///pointer to Voronoi place on the right side of edge
-    let right:Point
+    let right: Point
     ///directional vector, from "start", points to "end", normal of |left, right|
-    let direction:Point
+    let direction: Point
     ///pointer to end point
-    public var end:Point? = nil
-    var neighbour:Edge? = nil
-    
-    ///Directional coeffitient satisfying equation y = f*x + g (edge lies on this line)
-    var f:CGFloat
-    ///Directional coeffitient satisfying equation y = f*x + g (edge lies on this line)
-    var g:CGFloat
+    public var end: Point?
+    var neighbour: Edge?
 
-    
-    init(start:Point, left:Point, right:Point){
+    ///Directional coeffitient satisfying equation y = f*x + g (edge lies on this line)
+    var f: CGFloat
+    ///Directional coeffitient satisfying equation y = f*x + g (edge lies on this line)
+    var g: CGFloat
+
+    init(start: Point, left: Point, right: Point) {
         self.start = start
         self.left = left
         self.right = right
-        f = (right.x - left.x) / (left.y - right.y) ;
-        g = start.y - f * start.x ;
-        direction = Point(x:right.y - left.y, y:-(right.x - left.x));
+        f = (right.x - left.x) / (left.y - right.y)
+        g = start.y - f * start.x
+        direction = Point(x: right.y - left.y, y: -(right.x - left.x))
     }
-    
+
     func reverse() -> Edge {
         let e = Edge(start: end!, left: right, right: left)
         e.end = start
         return e
     }
 }
-

--- a/Voronoi/Event.swift
+++ b/Voronoi/Event.swift
@@ -7,44 +7,44 @@
 //
 
 import Foundation
-public class Event:Comparable,Hashable{
+public class Event: Comparable, Hashable {
     ///the point at which current event occurs (top circle point for circle event, focus point for place event)
-    let point:Point
-    
+    let point: Point
+
     //whether it is a place event or not
-    let pe:Bool
+    let pe: Bool
     ///If pe is true, it is an arch above which the event occurs
-    var arch:Parabola? = nil
-    
-    init(p:Point, pev:Bool){
-        point = p;
+    var arch: Parabola?
+
+    init(p: Point, pev: Bool) {
+        point = p
         pe = pev
     }
-    
+
     public var hashValue: Int {
         var hash = point.hashValue ^ pe.hashValue
-        if(arch != nil){
+        if(arch != nil) {
             hash = hash ^ 13
         }
         return hash
     }
 }
 
-public func <=(lhs: Event, rhs: Event) -> Bool{
+public func <=(lhs: Event, rhs: Event) -> Bool {
     return lhs.point.y <= rhs.point.y
 }
 
-public func >=(lhs: Event, rhs: Event) -> Bool{
+public func >=(lhs: Event, rhs: Event) -> Bool {
     return lhs.point.y >= rhs.point.y
 }
 
-public func <(lhs: Event, rhs: Event) -> Bool{
-    if(lhs.point.y - rhs.point.y < 1e-5 && lhs.point.y - rhs.point.y > -(1e-5)){
+public func <(lhs: Event, rhs: Event) -> Bool {
+    if(lhs.point.y - rhs.point.y < 1e-5 && lhs.point.y - rhs.point.y > -(1e-5)) {
         return lhs.point.x < rhs.point.x
     }
     return lhs.point.y < rhs.point.y
 }
 
-public func ==(lhs: Event, rhs: Event) -> Bool{
+public func ==(lhs: Event, rhs: Event) -> Bool {
     return lhs.point == rhs.point && lhs.pe == rhs.pe && lhs.arch === rhs.arch
 }

--- a/Voronoi/Parabola.swift
+++ b/Voronoi/Parabola.swift
@@ -8,116 +8,112 @@
 
 import Foundation
 
-
 /**
 A class that stores information about an item in beachline sequence (see Fortune's algorithm).
 It can represent an arch of parabola or an intersection between two archs (which defines an edge).
 In my implementation I build a binary tree with them (internal nodes are edges, leaves are archs).
 */
-public class Parabola{
+public class Parabola {
 
     ///Flag whether the node is Leaf or internal node
-    public var isLeaf = false;
-    
+    public var isLeaf = false
+
     //pointer to the focus point of parabola (when it is parabola)
-    public var site:Point!;
-    
+    public var site: Point!
+
     ///pointer to the edge (when it is an edge)
-    public var edge:Edge!;
-    
+    public var edge: Edge!
+
     ///Pointer to the event, when the arch disappears (circle event)
-    public var event:Event? = nil;
+    public var event: Event?
     ///Pointer to the parent node in tree
-    public var parent:Parabola?;
-    
+    public var parent: Parabola?
+
     /*
     Constructors of the class (empty for edge, with focus parameter for an arch).
     */
-    
-    init(){}
-    
-    init(s:Point){
+
+    init() {}
+
+    init(s: Point) {
         site = s
         isLeaf = true
     }
 
     ///Returns the closest left leaf of the tree
-    static func getLeft(_ p:Parabola) -> Parabola? {
-        return getLeftChild(getLeftParent(p));
+    static func getLeft(_ p: Parabola) -> Parabola? {
+        return getLeftChild(getLeftParent(p))
 
     }
-    
+
     ///Returns the closest right leaf of the tree
-    static func getRight(_ p:Parabola) -> Parabola? {
-        return getRightChild(getRightParent(p));
+    static func getRight(_ p: Parabola) -> Parabola? {
+        return getRightChild(getRightParent(p))
 
     }
-    
+
     ///Returns the closest parent which is on the left
-    static func getLeftParent(_ p:Parabola) -> Parabola? {
-        var par	= p.parent!;
-        var pLast = p;
-        while(par.left === pLast){
-            if let p = par.parent{
+    static func getLeftParent(_ p: Parabola) -> Parabola? {
+        var par	= p.parent!
+        var pLast = p
+        while(par.left === pLast) {
+            if let p = par.parent {
                 pLast = par
                 par = p
-            }
-            else{
+            } else {
                 return nil
             }
         }
-        return par;
+        return par
     }
-    
+
     ///Returns the closest parent which is on the right
-    static func getRightParent(_ p:Parabola) -> Parabola? {
-        var par	= p.parent!;
-        var pLast = p;
-        while(par.right === pLast){
-            if let p = par.parent{
+    static func getRightParent(_ p: Parabola) -> Parabola? {
+        var par	= p.parent!
+        var pLast = p
+        while(par.right === pLast) {
+            if let p = par.parent {
                 pLast = par
                 par = p
-            }
-            else{
+            } else {
                 return nil
             }
         }
-        return par;
+        return par
     }
-    
+
     ///Returns the closest leaf which is on the left of current node
-    static func getLeftChild(_ pin:Parabola?) -> Parabola? {
+    static func getLeftChild(_ pin: Parabola?) -> Parabola? {
         guard let p = pin else { return nil }
-        
+
         var par = p.left!
-        while(!par.isLeaf){
+        while(!par.isLeaf) {
             par = par.right
         }
-        return par;
+        return par
     }
-    
+
     ///Returns the closest leaf which is on the right of current node
-    static func getRightChild(_ pin:Parabola?) -> Parabola? {
+    static func getRightChild(_ pin: Parabola?) -> Parabola? {
         guard let p = pin else { return nil }
-        
+
         var par = p.right!
-        while(!par.isLeaf){
+        while(!par.isLeaf) {
             par = par.left
         }
-        return par;
+        return par
     }
-    
-    
+
     /*
     Access to the children (in tree).
     */
-    var left:Parabola! {
-        didSet{
+    var left: Parabola! {
+        didSet {
             left.parent = self
         }
     }
-    var right:Parabola! {
-        didSet{
+    var right: Parabola! {
+        didSet {
             right.parent = self
         }
     }

--- a/Voronoi/Point.swift
+++ b/Voronoi/Point.swift
@@ -8,31 +8,30 @@
 
 import Foundation
 
-public class Point:Equatable,Hashable {
-    public let x:CGFloat
-    public let y:CGFloat
-    
-    public init(x:CGFloat, y:CGFloat){
+public class Point: Equatable, Hashable {
+    public let x: CGFloat
+    public let y: CGFloat
+
+    public init(x: CGFloat, y: CGFloat) {
         self.x = x
         self.y = y
     }
-    
-    public var hashValue:Int{
+
+    public var hashValue: Int {
         return self.x.hashValue ^ self.y.hashValue
     }
-    
-    public var cgPoint:CGPoint{
+
+    public var cgPoint: CGPoint {
         return CGPoint(x: x, y: y)
     }
 }
 
-public func == (lhs:Point, rhs:Point)->Bool{
+public func == (lhs: Point, rhs: Point) -> Bool {
     return (lhs.y - rhs.y < 1e-5 && lhs.y - rhs.y > -(1e-5) ) && (lhs.x - rhs.x < 1e-5 && lhs.x - rhs.x > -(1e-5) )
 }
 
-
-extension Point: CustomStringConvertible{
-    public var description:String{
+extension Point: CustomStringConvertible {
+    public var description: String {
         let xStr = String(format: "%.2f", x)
         let yStr = String(format: "%.2f", y)
         return "(\(xStr),\(yStr))"

--- a/Voronoi/Polygon.swift
+++ b/Voronoi/Polygon.swift
@@ -8,8 +8,7 @@
 
 import UIKit
 
-
-fileprivate struct Line {
+private struct Line {
     let p1: CGPoint
     let p2: CGPoint
     func bounds() -> CGRect {
@@ -25,13 +24,13 @@ public class Polygon: NSObject {
 
     public let edges: [Edge]
     public let center: Point
-    
+
     public init(center: Point, edges: [Edge]) {
         self.edges = edges
         self.center = center
         super.init()
     }
-    
+
     public static func build(edges: [Edge], bounds: CGRect) -> [Polygon] {
         var map: [Point: [Edge]] = [:]
         for e in edges {
@@ -44,7 +43,7 @@ public class Polygon: NSObject {
                 map[p]?.append(e)
             }
         }
-        
+
         return map.map { (p: Point, edges: [Edge]) -> Polygon in
             var lines: [Line] = []
             for e in edges {
@@ -66,7 +65,7 @@ public class Polygon: NSObject {
             return Polygon(center: p, edges: sort(edges: allEdges))
         }
     }
-    
+
     public func bounds() -> CGRect {
         if edges.count == 0 { return CGRect.zero }
         var minP = edges[0].start.cgPoint
@@ -84,11 +83,11 @@ public class Polygon: NSObject {
                       width: maxP.x - minP.x,
                       height: maxP.y - minP.y)
     }
-    
+
     public func bezierPath() -> UIBezierPath {
         let path = UIBezierPath()
         if edges.count == 0 { return path }
-        
+
         path.move(to: edges[0].start.cgPoint)
         for e in edges {
             path.addLine(to: e.end!.cgPoint)
@@ -96,11 +95,11 @@ public class Polygon: NSObject {
         path.close()
         return path
     }
-    
+
     static func isClose(_ a: CGFloat, _ b: CGFloat) -> Bool {
         return abs(a-b) < 1e-5
     }
-    
+
     static func getBorderEdges(edges: [Edge], center: Point, bounds: CGRect) -> [Edge] {
         var onXBorder: [Point] = []
         var onYBorder: [Point] = []
@@ -114,16 +113,16 @@ public class Polygon: NSObject {
                 }
             }
         }
-        
+
         if onXBorder.count + onYBorder.count != 2 { return [] }
-        
+
         if onXBorder.count == 2 || onYBorder.count == 2 {
             let points = onXBorder + onYBorder
             let e = Edge(start: points[0], left: center, right: center)
             e.end = points[1]
             return [e]
         }
-        
+
         let cornerPoint = Point(x: onXBorder[0].x, y: onYBorder[0].y)
         let e1 = Edge(start: onXBorder[0], left: center, right: center)
         e1.end = cornerPoint
@@ -131,22 +130,22 @@ public class Polygon: NSObject {
         e2.end = cornerPoint
         return [e1, e2]
     }
-    
+
     static fileprivate func intersection(l1: Line, l2: Line) -> CGPoint? {
         // Store the values for fast access and easy
         // equations-to-code conversion
-        let x1 = l1.p1.x, x2 = l1.p2.x, x3 = l2.p1.x, x4 = l2.p2.x;
-        let y1 = l1.p1.y, y2 = l1.p2.y, y3 = l2.p1.y, y4 = l2.p2.y;
-        
-        let d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+        let x1 = l1.p1.x, x2 = l1.p2.x, x3 = l2.p1.x, x4 = l2.p2.x
+        let y1 = l1.p1.y, y2 = l1.p2.y, y3 = l2.p1.y, y4 = l2.p2.y
+
+        let d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
         // If d is zero, there is no intersection
         if (d == 0) { return nil }
-        
+
         // Get the x and y
-        let pre = (x1*y2 - y1*x2), post = (x3*y4 - y3*x4);
-        let x = ( pre * (x3 - x4) - (x1 - x2) * post ) / d;
-        let y = ( pre * (y3 - y4) - (y1 - y2) * post ) / d;
-        
+        let pre = (x1*y2 - y1*x2), post = (x3*y4 - y3*x4)
+        let x = ( pre * (x3 - x4) - (x1 - x2) * post ) / d
+        let y = ( pre * (y3 - y4) - (y1 - y2) * post ) / d
+
         let p = CGPoint(x: x, y: y)
         if l1.bounds().insetBy(dx: -0.1, dy: -0.1).contains(p) &&
             l2.bounds().insetBy(dx: -0.1, dy: -0.1).contains(p) {
@@ -154,7 +153,7 @@ public class Polygon: NSObject {
         }
         return nil
     }
-    
+
     static fileprivate func clipBounds(edges: [Edge], rect: CGRect) {
         let tl = CGPoint(x: rect.minX, y: rect.minY)
         let tr = CGPoint(x: rect.maxX, y: rect.minY)
@@ -181,13 +180,13 @@ public class Polygon: NSObject {
             }
         }
     }
-    
+
     static fileprivate func sort(edges: [Edge]) -> [Edge] {
         var edges = edges
-        
+
         // sort edges in circle
         var sortedEdges: [Edge] = []
-        
+
         var testCount = edges.count * 10
         while let e = edges.popLast() {
             testCount -= 1

--- a/Voronoi/PriorityQueue.swift
+++ b/Voronoi/PriorityQueue.swift
@@ -16,48 +16,48 @@ class PriorityQueue<T: Comparable>: CustomStringConvertible, MutableCollection {
             heap[position] = newValue
         }
     }
-    
+
     func index(after i: Int) -> Int {
         return i+1
     }
-    
+
     private final var heap: [T] = []
     private let contrast: (T, T) -> Bool
-    
+
     convenience init() {
         self.init(ascending: false, startingValues: [])
     }
-    
+
     convenience init(ascending: Bool) {
         self.init(ascending: ascending, startingValues: [])
     }
-    
+
     convenience init(startingValues: [T]) {
         self.init(ascending: false, startingValues: startingValues)
     }
-    
+
     init(ascending: Bool, startingValues: [T]) {
         if ascending {
             contrast = {$0 > $1}
         } else {
             contrast = {$0 < $1}
         }
-        
+
         for value in startingValues {
             push(value)
         }
     }
-    
+
     /// How many elements are in the Priority Queue?
     var count: Int {
         return heap.count
     }
-    
+
     /// Are there any elements in the Priority Queue?
     var isEmpty: Bool {
         return heap.isEmpty
     }
-    
+
     /// Add a new element onto the Priority Queue. O(lg n)
     ///
     /// :param: element The element to be inserted into the Priority Queue.
@@ -65,36 +65,36 @@ class PriorityQueue<T: Comparable>: CustomStringConvertible, MutableCollection {
         heap.append(element)
         swim((heap.count - 1))
     }
-    
+
     /// Remove and return the element with the highest priority (or lowest if ascending). O(lg n)
     ///
     /// :returns: The element with the highest priority in the Priority Queue, or nil if the PriorityQueue is empty.
     func pop() -> T? {
         if heap.isEmpty {
-            return nil;
+            return nil
         }
         heap.swapAt(0, (heap.count - 1))
         let temp: T = heap.removeLast()
         sink(0)
-        
+
         return temp
     }
-    
+
     /// Get a look at the current highest priority item, without removing it. O(1)
     ///
     /// :returns: The element with the highest priority in the PriorityQueue, or nil if the PriorityQueue is empty.
     func peek() -> T? {
         if heap.isEmpty {
-            return nil;
+            return nil
         }
         return heap[0]
     }
-    
+
     /// Eliminate all of the elements from the Priority Queue.
     func clear() {
         heap.removeAll(keepingCapacity: false)
     }
-    
+
     // Based on example from Sedgewick p 316
     private func sink(_ index: Int) {
         var k: Int = index
@@ -104,13 +104,13 @@ class PriorityQueue<T: Comparable>: CustomStringConvertible, MutableCollection {
                 j += 1
             }
             if !contrast(heap[k], heap[j]) {
-                break;
+                break
             }
             heap.swapAt(k, j)
             k = j
         }
     }
-    
+
     // Based on example from Sedgewick p 316
     private func swim(_ index: Int) {
         var k: Int = index
@@ -119,12 +119,12 @@ class PriorityQueue<T: Comparable>: CustomStringConvertible, MutableCollection {
             k = ((k - 1) / 2)
         }
     }
-    
+
     //Implement Printable protocol
     var description: String {
         return heap.description
     }
-    
+
     //Implement GeneratorType
     typealias Element = T
     func next() -> Element? {
@@ -133,20 +133,20 @@ class PriorityQueue<T: Comparable>: CustomStringConvertible, MutableCollection {
         }
         return nil
     }
-    
+
     //Implement SequenceType
     typealias Generator = PriorityQueue
     func generate() -> Generator {
         return self
     }
-    
+
     //Implement CollectionType
     typealias Index = Int
-    
+
     var startIndex: Int {
         return 0
     }
-    
+
     var endIndex: Int {
         return count
     }

--- a/Voronoi/Voronoi.swift
+++ b/Voronoi/Voronoi.swift
@@ -7,37 +7,35 @@
 //
 
 import Foundation
-public class Voronoi{
+public class Voronoi {
     ///Container of Points with which we work
-    private var places:[Point]!
-    
+    private var places: [Point]!
+
     ///Container of edges which will be the result
     private var edges = [Edge]()
 
     ///Width of the diagram
-    private var width:CGFloat = 0
-    
+    private var width: CGFloat = 0
+
     ///Height of the diagram
-    private var height:CGFloat = 0
-    
+    private var height: CGFloat = 0
+
     ///The root of the tree, that represents a beachline sequence
-    private var root:Parabola? = nil
+    private var root: Parabola?
 
     ///Current "y" position of the line (see Fortune's algorithm)
-    private var ly:CGFloat = 0;
-    
+    private var ly: CGFloat = 0
+
     ///set of deleted (false) Events (since we can not delete from PriorityQueue
-    var	deleted = Set<Event>();
-    
+    var	deleted = Set<Event>()
+
     ///list of all new points that were created during the algorithm
-    var points = [Point]();
-    
+    var points = [Point]()
+
     ///Priority queue with events to process
-    var queue = PriorityQueue<Event>();
-    
-    
-    
-    public init(){
+    var queue = PriorityQueue<Event>()
+
+    public init() {
     }
     ///
     ///The only public function for generating a diagram
@@ -47,313 +45,297 @@ public class Voronoi{
     ///:param: h The height of the result
     ///
     ///:returns: A list of edges
-    public func getEdges(v:[Point],w:CGFloat, h:CGFloat)->[Edge]{
-        places = v;
-        width = w;
-        height = h;
-        root = nil;
-        
+    public func getEdges(v: [Point], w: CGFloat, h: CGFloat) -> [Edge] {
+        places = v
+        width = w
+        height = h
+        root = nil
+
         points.removeAll(keepingCapacity: true)
         edges.removeAll(keepingCapacity: true)
-        if v.count < 3{
+        if v.count < 3 {
             return edges
         }
-        
-        for point in places
-        {
-            queue.push(Event(p: point, pev: true));
+
+        for point in places {
+            queue.push(Event(p: point, pev: true))
         }
-        
-        
-        while(!queue.isEmpty)
-        {
-            let e = queue.pop()!;
+
+        while(!queue.isEmpty) {
+            let e = queue.pop()!
             ly = e.point.y
-            
+
             if deleted.contains(e) {
                 deleted.remove(e)
                 continue
             }
 
-            
-            if(e.pe){
-                insertParabola(e.point);
-   
-            }
-            else{
-                removeParabola(e);
+            if(e.pe) {
+                insertParabola(e.point)
+
+            } else {
+                removeParabola(e)
             }
         }
-        
-        finishEdge(root!);
-        for edge in edges{
-            if let neigh = edge.neighbour{
+
+        finishEdge(root!)
+        for edge in edges {
+            if let neigh = edge.neighbour {
                 edge.start = neigh.end!
             }
             edge.neighbour = nil
 
         }
-        
+
         return edges
     }
 
     ///processing the place event
-    private func insertParabola(_ p:Point){
-        if let root = self.root{
-            
-            if(root.isLeaf && root.site.y - p.y < 1){
-                let fp = root.site!
-                root.isLeaf = false;
-                root.left = Parabola(s:fp)
-                root.right = Parabola(s:p)
-                let s = Point(x:(p.x + fp.x)/2,y: CGFloat(height));
-                points.append(s);
-                if(p.x > fp.x){
-                    root.edge = Edge(start:s,left: fp,right: p);
-                }
-                else{
-                    root.edge = Edge(start:s,left: p, right: fp);
-                }
-                edges.append(root.edge);
-                return;
-            }
-            
-            let par = getParabolaByX(p.x);
-            
-            if let pEvent = par.event{
-                deleted.insert(pEvent);
-                par.event = nil;
-            }
-            
-            let start = Point(x:p.x,y: getY(p: par.site, x: p.x));
-            points.append(start);
-            
-            let el = Edge(start:start, left:par.site,right: p);
-            let er = Edge(start:start, left: p, right:par.site);
-            
-            el.neighbour = er;
-            edges.append(el);
-            
+    private func insertParabola(_ p: Point) {
+        if let root = self.root {
 
-            par.edge = er;
-            par.isLeaf = false;
-            
-            let p0 = Parabola(s:par.site);
-            let p1 = Parabola(s:p);
-            let p2 = Parabola(s:par.site);
-            
-            par.right = p2;
-            par.left = Parabola();
-            par.left.edge = el;
-            
-            par.left.left = p0;
-            par.left.right = p1;
-            
-            checkCircle(p0);
-            checkCircle(p2);
-        }
-        else{
-            root = Parabola(s: p);
+            if(root.isLeaf && root.site.y - p.y < 1) {
+                let fp = root.site!
+                root.isLeaf = false
+                root.left = Parabola(s: fp)
+                root.right = Parabola(s: p)
+                let s = Point(x: (p.x + fp.x)/2, y: CGFloat(height))
+                points.append(s)
+                if(p.x > fp.x) {
+                    root.edge = Edge(start: s, left: fp, right: p)
+                } else {
+                    root.edge = Edge(start: s, left: p, right: fp)
+                }
+                edges.append(root.edge)
+                return
+            }
+
+            let par = getParabolaByX(p.x)
+
+            if let pEvent = par.event {
+                deleted.insert(pEvent)
+                par.event = nil
+            }
+
+            let start = Point(x: p.x, y: getY(p: par.site, x: p.x))
+            points.append(start)
+
+            let el = Edge(start: start, left: par.site, right: p)
+            let er = Edge(start: start, left: p, right: par.site)
+
+            el.neighbour = er
+            edges.append(el)
+
+            par.edge = er
+            par.isLeaf = false
+
+            let p0 = Parabola(s: par.site)
+            let p1 = Parabola(s: p)
+            let p2 = Parabola(s: par.site)
+
+            par.right = p2
+            par.left = Parabola()
+            par.left.edge = el
+
+            par.left.left = p0
+            par.left.right = p1
+
+            checkCircle(p0)
+            checkCircle(p2)
+        } else {
+            root = Parabola(s: p)
         }
     }
-    
+
     ///processing the circle event
-    private func removeParabola(_ e:Event){
-        let p1 = e.arch!;
-        
-        let xl = Parabola.getLeftParent(p1)!;
-        let xr = Parabola.getRightParent(p1)!;
-        
-        let p0 = Parabola.getLeftChild(xl)!;
-        let p2 = Parabola.getRightChild(xr)!;
-        
-        if(p0 === p2){
+    private func removeParabola(_ e: Event) {
+        let p1 = e.arch!
+
+        let xl = Parabola.getLeftParent(p1)!
+        let xr = Parabola.getRightParent(p1)!
+
+        let p0 = Parabola.getLeftChild(xl)!
+        let p2 = Parabola.getRightChild(xr)!
+
+        if(p0 === p2) {
             print("ERROR RIGHT AND LEFT HAVE SAME CHILD!")
         }
-        
-        if(p0.event != nil){
-            deleted.insert(p0.event!);
-            p0.event = nil;
+
+        if(p0.event != nil) {
+            deleted.insert(p0.event!)
+            p0.event = nil
         }
-        if(p2.event != nil){
-            deleted.insert(p2.event!);
-            p2.event = nil;
+        if(p2.event != nil) {
+            deleted.insert(p2.event!)
+            p2.event = nil
         }
-        
-        let p = Point(x: e.point.x, y: getY(p: p1.site, x: e.point.x));
-        points.append(p);
-        
-        xl.edge.end = p;
-        xr.edge.end = p;
-        
-        var higher = xl;
-        var par = p1;
-        while(par !== root)
-        {
-            par = par.parent!;
-            if(par === xl){
-                higher = xl;
+
+        let p = Point(x: e.point.x, y: getY(p: p1.site, x: e.point.x))
+        points.append(p)
+
+        xl.edge.end = p
+        xr.edge.end = p
+
+        var higher = xl
+        var par = p1
+        while(par !== root) {
+            par = par.parent!
+            if(par === xl) {
+                higher = xl
             }
             if(par === xr) {
-                higher = xr;
+                higher = xr
             }
         }
-        higher.edge = Edge(start: p, left: p0.site, right: p2.site);
-        edges.append(higher.edge);
-        
-        let gparent = p1.parent!.parent!;
-        if(p1.parent!.left === p1)
-        {
-            if(gparent.left  === p1.parent){
-                gparent.left = p1.parent!.right;
+        higher.edge = Edge(start: p, left: p0.site, right: p2.site)
+        edges.append(higher.edge)
+
+        let gparent = p1.parent!.parent!
+        if(p1.parent!.left === p1) {
+            if(gparent.left  === p1.parent) {
+                gparent.left = p1.parent!.right
 
             }
             if(gparent.right === p1.parent) {
-                gparent.right = p1.parent!.right;
+                gparent.right = p1.parent!.right
             }
-        }
-        else
-        {
-            if(gparent.left  === p1.parent){
+        } else {
+            if(gparent.left  === p1.parent) {
                 gparent.left = p1.parent?.left
             }
-            if(gparent.right === p1.parent){
+            if(gparent.right === p1.parent) {
                 gparent.right = p1.parent?.left
             }
         }
 
-        checkCircle(p0);
-        checkCircle(p2);
+        checkCircle(p0)
+        checkCircle(p2)
     }
-    
+
     ///recursively finishes all infinite edges in the tree
-    private func finishEdge(_ n:Parabola){
-        if(n.isLeaf){
-            return;
+    private func finishEdge(_ n: Parabola) {
+        if(n.isLeaf) {
+            return
         }
-        let mx:CGFloat;
-        if(n.edge.direction.x > 0.0){
-            mx = max(width,	n.edge.start.x + 10 );
+        let mx: CGFloat
+        if(n.edge.direction.x > 0.0) {
+            mx = max(width,	n.edge.start.x + 10 )
+        } else {
+            mx = min(0.0, n.edge.start.x - 10)
         }
-        else{
-            mx = min(0.0, n.edge.start.x - 10);
-        }
-        
-        let end = Point(x:mx,y: mx * n.edge.f + n.edge.g);
-        n.edge.end = end;
-        points.append(end);
-        
-        finishEdge(n.left);
-        finishEdge(n.right);
+
+        let end = Point(x: mx, y: mx * n.edge.f + n.edge.g)
+        n.edge.end = end
+        points.append(end)
+
+        finishEdge(n.left)
+        finishEdge(n.right)
 
     }
-    
+
     ///returns the current x position of an intersection point of left and right parabolas
-    private func getXOfEdge(par:Parabola, y:CGFloat) -> CGFloat {
-        
-        let left = Parabola.getLeftChild(par)!;
-        let right = Parabola.getRightChild(par)!;
-        
+    private func getXOfEdge(par: Parabola, y: CGFloat) -> CGFloat {
+
+        let left = Parabola.getLeftChild(par)!
+        let right = Parabola.getRightChild(par)!
+
         let p = left.site!
         let r = right.site!
-        
-        var dp = 2.0 * (p.y - y);
-        let a1 = 1.0 / dp;
-        let b1 = -2.0 * p.x / dp;
-        let c1 = y + dp / 4 + p.x * p.x / dp;
-        
-        dp = 2.0 * (r.y - y);
-        let a2 = 1.0 / dp;
-        let b2 = -2.0 * r.x/dp;
-        let c2 = ly + dp / 4 + r.x * r.x / dp;
-        
-        let a = a1 - a2;
-        let b = b1 - b2;
-        let c = c1 - c2;
-        
-        let disc = b*b - 4 * a * c;
-        let x1 = (-b + sqrt(disc)) / (2*a);
-        let x2 = (-b - sqrt(disc)) / (2*a);
-        
-        let ry:CGFloat
-        if(p.y < r.y ){
-            ry = max(x1, x2);
+
+        var dp = 2.0 * (p.y - y)
+        let a1 = 1.0 / dp
+        let b1 = -2.0 * p.x / dp
+        let c1 = y + dp / 4 + p.x * p.x / dp
+
+        dp = 2.0 * (r.y - y)
+        let a2 = 1.0 / dp
+        let b2 = -2.0 * r.x/dp
+        let c2 = ly + dp / 4 + r.x * r.x / dp
+
+        let a = a1 - a2
+        let b = b1 - b2
+        let c = c1 - c2
+
+        let disc = b*b - 4 * a * c
+        let x1 = (-b + sqrt(disc)) / (2*a)
+        let x2 = (-b - sqrt(disc)) / (2*a)
+
+        let ry: CGFloat
+        if(p.y < r.y ) {
+            ry = max(x1, x2)
         } else {
-            ry = min(x1, x2);
+            ry = min(x1, x2)
         }
-        return ry;
+        return ry
     }
-    
+
     ///returns the Parabola that is under this "x" position in the current beachline
-    private func getParabolaByX(_ xx:CGFloat)->Parabola{
-        var par = root!;
-        var x: CGFloat = 0.0;
-        
+    private func getParabolaByX(_ xx: CGFloat) -> Parabola {
+        var par = root!
+        var x: CGFloat = 0.0
+
         while(!par.isLeaf) // projdu stromem dokud nenarazÌm na vhodn˝ list
         {
-            x = getXOfEdge(par: par, y: ly);
-            if(x>xx){
+            x = getXOfEdge(par: par, y: ly)
+            if(x>xx) {
                 par = par.left
-            }
-            else{
-                par = par.right;
+            } else {
+                par = par.right
             }
         }
-        return par;
+        return par
     }
-    
-    private func getY(p:Point, x:CGFloat)->CGFloat{
-        let dp = 2 * (p.y - ly);
-        let a1 = 1 / dp;
-        let b1 = -2 * p.x / dp;
-        let c1 = ly + dp / 4 + p.x * p.x / dp;
-        
-        return (a1*x*x + b1*x + c1);
+
+    private func getY(p: Point, x: CGFloat) -> CGFloat {
+        let dp = 2 * (p.y - ly)
+        let a1 = 1 / dp
+        let b1 = -2 * p.x / dp
+        let c1 = ly + dp / 4 + p.x * p.x / dp
+
+        return (a1*x*x + b1*x + c1)
     }
-    
+
     ///checks the circle event (disappearing) of this parabola
-    private func checkCircle(_ b:Parabola){
-        let lp = Parabola.getLeftParent(b);
-        let rp = Parabola.getRightParent(b);
-        
+    private func checkCircle(_ b: Parabola) {
+        let lp = Parabola.getLeftParent(b)
+        let rp = Parabola.getRightParent(b)
+
         if let a  = Parabola.getLeftChild(lp), let c = Parabola.getRightChild(rp) {
-            if(a.site === c.site){
-                return;
+            if(a.site === c.site) {
+                return
             }
-        
-            if let s = getEdgeIntersection(a: lp!.edge, b: rp!.edge){
-                let dx = a.site.x - s.x;
-                let dy = a.site.y - s.y;
-                
-                let d = sqrt( (dx * dx) + (dy * dy) );
-                
-                if(s.y - d >= ly){
-                    return;
+
+            if let s = getEdgeIntersection(a: lp!.edge, b: rp!.edge) {
+                let dx = a.site.x - s.x
+                let dy = a.site.y - s.y
+
+                let d = sqrt( (dx * dx) + (dy * dy) )
+
+                if(s.y - d >= ly) {
+                    return
                 }
-                let e = Event(p: Point(x:s.x, y: s.y - d), pev: false);
-                points.append(e.point);
-                b.event = e;
-                e.arch = b;
-                queue.push(e);
+                let e = Event(p: Point(x: s.x, y: s.y - d), pev: false)
+                points.append(e.point)
+                b.event = e
+                e.arch = b
+                queue.push(e)
             }
         }
     }
-    
-    private func getEdgeIntersection(a:Edge, b:Edge)->Point?{
-        let x = (b.g - a.g) / (a.f - b.f);
-        let y = a.f * x + a.g;
-        
-        if((x - a.start.x)/a.direction.x < 0){ return nil};
-        if((y - a.start.y)/a.direction.y < 0){ return nil}
-        if((x - b.start.x)/b.direction.x < 0){ return nil}
-        if((y - b.start.y)/b.direction.y < 0){ return nil}
-        
-        let p = Point(x:x,y: y);
-        points.append(p);
-        return p;
-        
-        
+
+    private func getEdgeIntersection(a: Edge, b: Edge) -> Point? {
+        let x = (b.g - a.g) / (a.f - b.f)
+        let y = a.f * x + a.g
+
+        if((x - a.start.x)/a.direction.x < 0) { return nil}
+        if((y - a.start.y)/a.direction.y < 0) { return nil}
+        if((x - b.start.x)/b.direction.x < 0) { return nil}
+        if((y - b.start.y)/b.direction.y < 0) { return nil}
+
+        let p = Point(x: x, y: y)
+        points.append(p)
+        return p
+
     }
-    
-    
+
 }


### PR DESCRIPTION
The usage of generics in TransitionAnimator is confusing now because developers can use generics but at the same time use arrays as source and destination types definition. First of all, I've made the TransitionAnimator with generics a just subclass of more common class which contains all logic.
Also there are lot of fixes with naming, private/fileprivate usage, spaces and so on.